### PR TITLE
fix: logout on auth problem

### DIFF
--- a/src/Helpers/firebase.js
+++ b/src/Helpers/firebase.js
@@ -36,7 +36,7 @@ export class FirebaseDbService {
         const roleRef = userDoc.data().Role;
         return await this.fetchUserRole(roleRef); 
       } catch (error) {
-        throw new Error("Failed to retrieve User's Role")
+        throw new Error(`Failed to retrieve User's Role: ${error.message}`)
       }
     }
     return null;

--- a/src/Helpers/firebase.js
+++ b/src/Helpers/firebase.js
@@ -32,8 +32,12 @@ export class FirebaseDbService {
     const userDocRef = doc(db, 'Users', userId);
     const userDoc = await getDoc(userDocRef);
     if (userDoc.exists()) {
-      const roleRef = userDoc.data().Role;
-      return await this.fetchUserRole(roleRef);
+      try {
+        const roleRef = userDoc.data().Role;
+        return await this.fetchUserRole(roleRef); 
+      } catch (error) {
+        throw new Error("Failed to retrieve User's Role")
+      }
     }
     return null;
   }

--- a/src/components/AuthProvider.js
+++ b/src/components/AuthProvider.js
@@ -10,7 +10,7 @@ export const signInWithGoogle = async () => {
   try {
     await signInWithPopup(auth, new GoogleAuthProvider());
   } catch (error) {
-    console.error("Error signing in with Google: ", error.message);
+    logger.error("Error signing in with Google: ", error.message);
   }
 };
 
@@ -18,7 +18,7 @@ export const signInWithEmail = async (email, password) => {
   try {
     await signInWithEmailAndPassword(auth, email, password);
   } catch (error) {
-    console.error("Error signing in with email and password: ", error.message);
+    logger.error("Error signing in with email and password: ", error.message);
   }
 };
 
@@ -67,7 +67,7 @@ export const AuthProvider = ({ children }) => {
         setCurrentUser(loggedInUser);
         setLoading(false);
       } catch (err) {
-        console.error("Error during post-auth user fetch:", err);
+        logger.error("Error during post-auth user fetch:", err);
 
         // Flag for debugging if it's a permissions issue
         const isPermissionError =
@@ -76,9 +76,9 @@ export const AuthProvider = ({ children }) => {
           err?.message?.includes("PERMISSION_DENIED");
       
         if (isPermissionError) {
-          console.warn("Permission denied while accessing user data. User will be signed out.");
+          logger.warn("Permission denied while accessing user data. User will be signed out.");
         } else {
-          console.warn("Unexpected error during post-auth load. User will be signed out.");
+          logger.warn("Unexpected error during post-auth load. User will be signed out.");
         }
       
         // Always sign the user out on error

--- a/src/components/AuthProvider.js
+++ b/src/components/AuthProvider.js
@@ -30,36 +30,7 @@ export const AuthProvider = ({ children }) => {
   const [loading, setLoading] = useState(true);
   const [dbService, setDbService] = useState(null);
   const auth = getAuth(app);
-
-  useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, async (user) => {
-      if (!user) {
-        setCurrentUser(null);
-        setLoading(false);
-        return;
-      }
-      
-      const tempDbService = new FirebaseDbService(user);
-
-      const userRole = await tempDbService.fetchRoleByUserId(user.uid)
-      const userPhoto = await tempDbService.fetchAvatarPhotoByUserId(user.uid)
-
-      const loggedInUser = {
-        ...user,
-        role: userRole,
-        photoURL: userPhoto
-      }
-
-      setDbService(new FirebaseDbService(loggedInUser));
-      setCurrentUser(loggedInUser);
-      setLoading(false);
-    });
-
-    return () => {
-      unsubscribe();
-    };
-  }, [auth]);
-
+  
   const logout = async () => {
     try {
       await auth.signOut();
@@ -68,6 +39,58 @@ export const AuthProvider = ({ children }) => {
       logger.error("Error logging out: ", error);
     }
   };
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, async (user) => {
+      if (!user) {
+        setCurrentUser(null);
+        setLoading(false);
+        return;
+      }
+  
+      try {
+        const tempDbService = new FirebaseDbService(user);
+  
+        // Try to fetch user role
+        const userRole = await tempDbService.fetchRoleByUserId(user.uid);
+  
+        // Try to fetch avatar
+        const userPhoto = await tempDbService.fetchAvatarPhotoByUserId(user.uid);
+  
+        const loggedInUser = {
+          ...user,
+          role: userRole,
+          photoURL: userPhoto
+        };
+  
+        setDbService(new FirebaseDbService(loggedInUser));
+        setCurrentUser(loggedInUser);
+        setLoading(false);
+      } catch (err) {
+        console.error("Error during post-auth user fetch:", err);
+
+        // Flag for debugging if it's a permissions issue
+        const isPermissionError =
+          err?.code === "permission-denied" ||
+          err?.message?.includes("Missing or insufficient permissions") ||
+          err?.message?.includes("PERMISSION_DENIED");
+      
+        if (isPermissionError) {
+          console.warn("Permission denied while accessing user data. User will be signed out.");
+        } else {
+          console.warn("Unexpected error during post-auth load. User will be signed out.");
+        }
+      
+        // Always sign the user out on error
+        await logout()
+        setCurrentUser(null);
+        setLoading(false);
+      }
+    });
+  
+    return () => unsubscribe();
+  }, [auth]);
+  
 
   return (
     <AuthContext.Provider value={{ currentUser, logout, dbService }}>


### PR DESCRIPTION
With ongoing changes to the firebase security rules, it's been commonplace to run into cases where failing data fetches cause the interface to fail. This prevents switching users for different access permissions and stifles debugging. 

As a fix, I'm updating the Auth Provider to log the current user out on any auth failure and provide better error context. 