### PR TITLE
Add `joi` runtime data validation

### DIFF
--- a/.eslintrc-todo.json
+++ b/.eslintrc-todo.json
@@ -1,0 +1,22 @@
+{
+  "root": true,
+  "parserOptions": {
+    "ecmaVersion": 2023,
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "jsx": true
+    }
+  },
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "rules": {
+    "no-warning-comments": [ 1,
+      {
+        "terms": ["todo"],
+        "location": "start"
+      }
+    ]
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@welldone-software/why-did-you-render": "^8",
         "firebase": "^10.10.0",
         "firebaseui": "^6.1.0",
+        "joi": "^17.13.3",
         "polished": "^4.3.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -3237,6 +3238,19 @@
         "node": ">=12"
       }
     },
+    "node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -4649,6 +4663,24 @@
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.1.tgz",
       "integrity": "sha512-S3Kq8e7LqxkA9s7HKLqXGTGck1uwis5vAXan3FnU5yw1Ec5hsSGnq4s/UCaSqABPOnOTg7zASLyst7+ohgWexg=="
+    },
+    "node_modules/@sideway/address": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.24.51",
@@ -13534,6 +13566,18 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/joi": {
+      "version": "17.13.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "dependencies": {
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -22179,6 +22223,19 @@
         }
       }
     },
+    "@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+    },
+    "@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -23123,6 +23180,24 @@
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.1.tgz",
       "integrity": "sha512-S3Kq8e7LqxkA9s7HKLqXGTGck1uwis5vAXan3FnU5yw1Ec5hsSGnq4s/UCaSqABPOnOTg7zASLyst7+ohgWexg=="
+    },
+    "@sideway/address": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "@sinclair/typebox": {
       "version": "0.24.51",
@@ -29570,6 +29645,18 @@
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
       "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q=="
+    },
+    "joi": {
+      "version": "17.13.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "requires": {
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
+      }
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "firebase": "^10.10.0",
         "firebaseui": "^6.1.0",
         "joi": "^17.13.3",
+        "luxon": "^3.7.1",
         "polished": "^4.3.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -13949,6 +13950,14 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.1.tgz",
+      "integrity": "sha512-RkRWjA926cTvz5rAb1BqyWkKbbjzCGchDUIKMCUvNi17j6f6j8uHGDV82Aqcqtzd+icoYpELmG3ksgGiFNNcNg==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/lz-string": {
@@ -29968,6 +29977,11 @@
       "requires": {
         "yallist": "^3.0.2"
       }
+    },
+    "luxon": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.1.tgz",
+      "integrity": "sha512-RkRWjA926cTvz5rAb1BqyWkKbbjzCGchDUIKMCUvNi17j6f6j8uHGDV82Aqcqtzd+icoYpELmG3ksgGiFNNcNg=="
     },
     "lz-string": {
       "version": "1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@fullcalendar/list": "^6.1.11",
         "@fullcalendar/react": "^6.1.11",
         "@fullcalendar/timegrid": "^6.1.11",
+        "@hookform/resolvers": "^5.1.1",
         "@mui/icons-material": "^5.15.15",
         "@mui/material": "^5.15.15",
         "@reduxjs/toolkit": "^2.2.7",
@@ -3251,6 +3252,17 @@
         "@hapi/hoek": "^9.0.0"
       }
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.1.1.tgz",
+      "integrity": "sha512-J/NVING3LMAEvexJkyTLjruSm7aOFx7QX21pzkiJfMoNG0wl5aFEjLTl7ay7IQb9EWY6AkrBy7tHL2Alijpdcg==",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -4702,6 +4714,11 @@
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
       }
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
@@ -16573,18 +16590,18 @@
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
     "node_modules/react-hook-form": {
-      "version": "7.51.2",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.51.2.tgz",
-      "integrity": "sha512-y++lwaWjtzDt/XNnyGDQy6goHskFualmDlf+jzEZvjvz6KWDf7EboL7pUvRCzPTJd0EOPpdekYaQLEvvG6m6HA==",
+      "version": "7.58.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.58.1.tgz",
+      "integrity": "sha512-Lml/KZYEEFfPhUVgE0RdCVpnC4yhW+PndRhbiTtdvSlQTL8IfVR+iQkBjLIvmmc6+GGoVeM11z37ktKFPAb0FA==",
       "engines": {
-        "node": ">=12.22.0"
+        "node": ">=18.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/react-hook-form"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17 || ^18"
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {
@@ -22236,6 +22253,14 @@
         "@hapi/hoek": "^9.0.0"
       }
     },
+    "@hookform/resolvers": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.1.1.tgz",
+      "integrity": "sha512-J/NVING3LMAEvexJkyTLjruSm7aOFx7QX21pzkiJfMoNG0wl5aFEjLTl7ay7IQb9EWY6AkrBy7tHL2Alijpdcg==",
+      "requires": {
+        "@standard-schema/utils": "^0.3.0"
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -23219,6 +23244,11 @@
       "requires": {
         "@sinonjs/commons": "^1.7.0"
       }
+    },
+    "@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="
     },
     "@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
@@ -31645,9 +31675,9 @@
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
     "react-hook-form": {
-      "version": "7.51.2",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.51.2.tgz",
-      "integrity": "sha512-y++lwaWjtzDt/XNnyGDQy6goHskFualmDlf+jzEZvjvz6KWDf7EboL7pUvRCzPTJd0EOPpdekYaQLEvvG6m6HA==",
+      "version": "7.58.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.58.1.tgz",
+      "integrity": "sha512-Lml/KZYEEFfPhUVgE0RdCVpnC4yhW+PndRhbiTtdvSlQTL8IfVR+iQkBjLIvmmc6+GGoVeM11z37ktKFPAb0FA==",
       "requires": {}
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@fullcalendar/list": "^6.1.11",
     "@fullcalendar/react": "^6.1.11",
     "@fullcalendar/timegrid": "^6.1.11",
+    "@hookform/resolvers": "^5.1.1",
     "@mui/icons-material": "^5.15.15",
     "@mui/material": "^5.15.15",
     "@reduxjs/toolkit": "^2.2.7",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@welldone-software/why-did-you-render": "^8",
     "firebase": "^10.10.0",
     "firebaseui": "^6.1.0",
+    "joi": "^17.13.3",
     "polished": "^4.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "firebase": "^10.10.0",
     "firebaseui": "^6.1.0",
     "joi": "^17.13.3",
+    "luxon": "^3.7.1",
     "polished": "^4.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "todo-check": "eslint --no-eslintrc -c .eslintrc-todo.json \"src/**/*.{js,jsx}\""
   },
   "eslintConfig": {
     "extends": [

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -36,3 +36,10 @@ export const RESERVATION_STATUS = Object.freeze({
   REFUNDED: 'refunded',       // Payment was received but later refunded
   COMPED: 'comped',           // Payment was waived, no fees apply
 })
+
+export const GENDERS = Object.freeze({
+  MALE: "Male",
+  FEMALE: "Female",
+  OTHER: "Other",
+  UNSPECIFIED: "Unspecified",
+})

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -44,4 +44,14 @@ export const GENDERS = Object.freeze({
   UNSPECIFIED: "Unspecified",
 })
 
+export const CONTACT_RELATIONS = Object.freeze({
+  PARENT: 'Parent',
+  FAMILY: 'Family',
+  LEGAL_GUARDIAN: 'Legal Guardian',
+  FAMILY_FRIEND: 'Family Friend',
+  DOCTOR: 'Doctor',
+  PROFESSIONAL_CAREGIVER: 'Professional Caregiver',
+  OTHER: 'Other',
+})
+
 export const MIN_AGE_FOR_CHILD_YEARS = 2; 

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -43,3 +43,5 @@ export const GENDERS = Object.freeze({
   OTHER: "Other",
   UNSPECIFIED: "Unspecified",
 })
+
+export const MIN_AGE_FOR_CHILD_YEARS = 2; 

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -1,17 +1,38 @@
-export const COLLECTIONS = {
+export const COLLECTIONS = Object.freeze({
   CHILDREN: 'Children',
   USERS: 'Users',
   CONTACTS: 'Contacts',
   PERMISSIONS: 'Parent_Authorized_Permissions',
   RESERVATIONS: 'Reservations',
   ROLES: 'Roles',
-}
+})
 
 export const MIN_RESERVATION_DURATION_MS = 2 * 60 * 60 * 1000; // 2 hours in milliseconds
 
-export const BUSINESS_HRS = {
+export const BUSINESS_HRS = Object.freeze({
   daysOfWeek: [1, 2, 3, 4, 5], // Monday - Friday
   startTime: '07:00',
   endTime: '19:00',
   overlap: false
-};
+})
+
+export const ROLES = Object.freeze({
+  ADMIN: 'admin',
+  PARENT: 'parent-user',
+})
+
+export const RESERVATION_STATUS = Object.freeze({
+  PENDING: 'pending',         // Represents a reservation that is awaiting confirmation by the admin
+  CONFIRMED: 'confirmed',     // Represents time between reservation confirmation and service rendered
+  CANCELLED: 'cancelled',     // Represents a reservation that does not require payment
+  NO_SHOW: 'no-show',         // Represents a reservation that was not attended. Fees may apply.
+
+  // The following statuses are used for billing purposes
+
+  PROCESSING: 'processing',   // Represents time between rendered service and invoice creation
+  UNPAID: 'unpaid',
+  PAID: 'paid',
+  LATE: 'late',
+  REFUNDED: 'refunded',       // Payment was received but later refunded
+  COMPED: 'comped',           // Payment was waived, no fees apply
+})

--- a/src/Helpers/datetime.js
+++ b/src/Helpers/datetime.js
@@ -1,0 +1,42 @@
+import { Timestamp } from "firebase/firestore";
+import { DateTime } from "luxon";
+
+
+export const luxonDateTimeFromFirebaseTimestamp = (() => {
+  const luxonFBCache = new Map();
+
+  return (ts) => {
+    const key = ts.toMillis();
+    if (!luxonFBCache.has(key)) {
+      const dt = DateTime.fromMillis(key);
+      luxonFBCache.set(key, dt);
+    }
+    return luxonFBCache.get(key);
+  }
+})();
+
+export const luxonDateTimeFromJSDate = (() => {
+  const luxonJSCache = new Map();
+
+  return (jsd) => {
+    const key = jsd.getMilliseconds();
+    if (!luxonJSCache.has(key)) {
+      const dt = DateTime.fromMillis(key);
+      luxonJSCache.set(key, dt);
+    }
+    return luxonJSCache.get(key);
+  }
+})();
+
+export const luxonDateTimeFromISOString = (() => {
+  const luxonISOCache = new Map();
+  return (isoString) => {
+    if (!luxonISOCache.has(isoString)) {
+      const dt = DateTime.fromISO(isoString);
+      luxonISOCache.set(isoString, dt);
+    }
+    return luxonISOCache.get(isoString);
+  }
+})();
+
+export const firebaseTimestampFromLuxonDateTime = (dt) => Timestamp.fromMillis(dt.toMillis());

--- a/src/Helpers/datetime.js
+++ b/src/Helpers/datetime.js
@@ -40,3 +40,20 @@ export const luxonDateTimeFromISOString = (() => {
 })();
 
 export const firebaseTimestampFromLuxonDateTime = (dt) => Timestamp.fromMillis(dt.toMillis());
+
+/**
+ * Checks if an event date falls within a specific calendar day
+ * @param {string|Date} eventDate - The event date (ISO string or Date object)
+ * @param {Date} calendarDay - The calendar day to check against
+ * @returns {boolean} - True if the event falls on the calendar day
+ */
+export const isEventOnCalendarDay = (eventDate, calendarDay) => {
+  const event = new Date(eventDate);
+  const day = new Date(calendarDay);
+  
+  // Set both dates to start of day for comparison
+  const eventStartOfDay = new Date(event.getFullYear(), event.getMonth(), event.getDate());
+  const calendarStartOfDay = new Date(day.getFullYear(), day.getMonth(), day.getDate());
+  
+  return eventStartOfDay.getTime() === calendarStartOfDay.getTime();
+};

--- a/src/Helpers/firebase.js
+++ b/src/Helpers/firebase.js
@@ -4,6 +4,7 @@ import { ref, uploadBytes, getDownloadURL } from "@firebase/storage";
 import { storage } from "../config/firebase";
 import { createUserWithEmailAndPassword, deleteUser } from "firebase/auth";
 import { logger } from "./logger";
+import { generateChildSchema } from "../schemas/ChildSchema";
 
 
 export class FirebaseDbService {
@@ -38,7 +39,11 @@ export class FirebaseDbService {
   }
 
   #mapSnapshotToData(snapshot) {
-    return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+    try {
+      return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+    } catch (error) {
+      console.error("Error mapping snapshot to data:", error);
+    }
   }
 
   /**
@@ -75,7 +80,11 @@ export class FirebaseDbService {
       this.validateAuth();
     }
     return onSnapshot(ref, (snapshot) => {
-      callback(this.#mapSnapshotToData(snapshot));
+      try {
+        callback(this.#mapSnapshotToData(snapshot));
+      } catch (error) {
+        console.error("Error subscribing to documents:", error);
+      }
     });
   }
 
@@ -89,7 +98,6 @@ export class FirebaseDbService {
    */
   createChildDocument = async (childData) => {
     this.validateAuth();
-    childData.archived = false;
     try {
       const docRef = await addDoc(collection(db, "Children"), childData);
       const userRef = doc(collection(db, "Users"), this.userContext.uid);

--- a/src/Helpers/firebase.js
+++ b/src/Helpers/firebase.js
@@ -433,7 +433,7 @@ export class FirebaseDbService {
    * @throws {Error} - If there is an error updating the document.
    * */
   changeReservationStatus = async (reservationId, newStatus) => {
-    this.validateAuth('admin');
+    this.validateAuth(); // TODO: Add admin validation after demonstration
     try {
       const reservationRef = doc(collection(db, "Reservations"), reservationId);
       await updateDoc(reservationRef, { extendedProps: { status: newStatus } });

--- a/src/Helpers/firebase.js
+++ b/src/Helpers/firebase.js
@@ -4,7 +4,6 @@ import { ref, uploadBytes, getDownloadURL } from "@firebase/storage";
 import { storage } from "../config/firebase";
 import { createUserWithEmailAndPassword, deleteUser } from "firebase/auth";
 import { logger } from "./logger";
-import { generateChildSchema } from "../schemas/ChildSchema";
 
 
 export class FirebaseDbService {

--- a/src/Helpers/firebase.js
+++ b/src/Helpers/firebase.js
@@ -433,7 +433,7 @@ export class FirebaseDbService {
    * @throws {Error} - If there is an error updating the document.
    * */
   changeReservationStatus = async (reservationId, newStatus) => {
-    this.validateAuth(); // TODO: Add admin validation after demonstration
+    this.validateAuth('admin');
     try {
       const reservationRef = doc(collection(db, "Reservations"), reservationId);
       await updateDoc(reservationRef, { extendedProps: { status: newStatus } });

--- a/src/Helpers/util.js
+++ b/src/Helpers/util.js
@@ -1,4 +1,5 @@
 
+
 /**
  * Calculates the age based on the given date of birth.
  *
@@ -6,7 +7,7 @@
  * @returns {number} The calculated age.
  */
 export function calculateAge(dob) {
-  const birthDate = new Date(dob);
+  const birthDate = ifTimestampMakeDate(dob);            // TODO: make sure the date format coming in is consistent
   const today = new Date();
   let age = today.getFullYear() - birthDate.getFullYear();
   const m = today.getMonth() - birthDate.getMonth();
@@ -14,6 +15,20 @@ export function calculateAge(dob) {
       age--;
   }
   return age;
+}
+
+
+/**
+ * Converts a timestamp or date-like object to a JavaScript Date object.
+ *
+ * If the input has a `toDate` method (e.g., a Firestore Timestamp), it calls that method.
+ * Otherwise, it creates a new Date object from the input.
+ *
+ * @param {any} ts - The timestamp or date-like object to convert.
+ * @returns {Date} The resulting JavaScript Date object.
+ */
+export function ifTimestampMakeDate(ts) {
+  return ts.toDate ? ts.toDate() : new Date(ts);
 }
 
 /**

--- a/src/Hooks/query-related/useChildrenRQ.js
+++ b/src/Hooks/query-related/useChildrenRQ.js
@@ -9,8 +9,9 @@ export function useChildrenRQ() {
   const { dbService, currentUser } = useAuth();
   const queryClient = useQueryClient();
   const isAdmin = currentUser?.Role === 'admin';
-  const queryKey = isAdmin ? ['adminAllChildren'] : ['fetchChildren', currentUser.Email];
-
+  const queryKey = useMemo(() => {
+    return isAdmin ? ['adminAllChildren'] : ['fetchChildren', currentUser.Email];
+  }, [currentUser?.Email, isAdmin]);
 
   // First, build the query
   const allChildrenQuery = useMemo(() => query(

--- a/src/Hooks/query-related/useReservationsByMonthDayRQ.js
+++ b/src/Hooks/query-related/useReservationsByMonthDayRQ.js
@@ -6,6 +6,7 @@ import { COLLECTIONS } from "../../Helpers/constants";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { logger } from "../../Helpers/logger";
 import _ from "lodash";
+import { luxonDateTimeFromFirebaseTimestamp } from "../../Helpers/datetime";
 
 export function useReservationsByMonthDayRQ() {
   const { dbService, currentUser } = useAuth();
@@ -16,13 +17,13 @@ export function useReservationsByMonthDayRQ() {
   const queryKey = useMemo(() => {
     if (monthYear.day != null && !monthYear.week) {
       // Fetch reservations for a specific day
-      return ['adminCalendarReservationsByDay', monthYear.day, monthYear.month, monthYear.year];
+      return ['calendarReservationsByDay', monthYear.day, monthYear.month, monthYear.year];
     } else if (monthYear.day != null && monthYear.week) {
       // Fetch reservations for a specific week
-      return ['adminCalendarReservationsByWeek', monthYear.day, monthYear.month, monthYear.year];
+      return ['calendarReservationsByWeek', monthYear.day, monthYear.month, monthYear.year];
     } else {
       // Fetch reservations for the entire month
-      return ['adminCalendarReservationsByMonth', monthYear.month, monthYear.year];
+      return ['calendarReservationsByMonth', monthYear.month, monthYear.year];
     }
   }, [monthYear]);
 
@@ -85,8 +86,10 @@ export function useReservationsByMonthDayRQ() {
       status: res.extendedProps.status,
       childId: res.extendedProps.childId,
       title: res.title || "",
-      start: new Date(res.start.seconds * 1000),
-      end: new Date(res.end.seconds * 1000),
+      start: luxonDateTimeFromFirebaseTimestamp(res.start).toISO(),
+      end: luxonDateTimeFromFirebaseTimestamp(res.end).toISO(),
+      startDT: luxonDateTimeFromFirebaseTimestamp(res.start),
+      endDT: luxonDateTimeFromFirebaseTimestamp(res.end),
     };
 
   };

--- a/src/components/Dashboard/ManageReservationsPage.js
+++ b/src/components/Dashboard/ManageReservationsPage.js
@@ -65,6 +65,7 @@ const ManageReservationsPage = () => {
   }, [dialogReservationContext]);
 
   const reservationTimeChangeMutation = useMutation({
+    mutationKey: ['changeReservationTime'],
     mutationFn: async ({ id, newStart, newEnd }) => dbService.changeReservationTime(id, newStart, newEnd),
     onSuccess: () => {
       queryClient.invalidateQueries(
@@ -137,6 +138,7 @@ const ManageReservationsPage = () => {
 
   const reservationStatusMutation = useMutation(
     {
+      mutationKey: ['changeReservationStatus'],
       mutationFn: async ({ id, status }) => dbService.changeReservationStatus(id, status),
       onSuccess: () => {
         queryClient.invalidateQueries(

--- a/src/components/Pages/ChildRegistration.js
+++ b/src/components/Pages/ChildRegistration.js
@@ -79,16 +79,16 @@ const ChildRegistration = ({ setOpenState }) => {
           {errors.Name?.message && <p>{errors.Name.message}</p>}
 
           <label htmlFor="DOB" className="form-label">DOB:</label>
-          <input type="date" id="DOB" {...register('DOB', { required: true })} className="form-control" />
+          <input type="date" id="DOB" {...register('DOB')} className="form-control" />
           {errors.DOB?.message && <p>{errors.DOB.message}</p>}
 
           <label htmlFor="Gender" className="form-label">Gender:</label>
-          <select id="Gender" {...register('Gender', { required: true })} className="form-control">
+          <select id="Gender" {...register('Gender')} className="form-control">
             {Object.values(GENDERS).map(option => {
               return <option key={option} value={option}>{option}</option>;
             })}
           </select>
-          {errors.Gender && <p>Gender is required</p>}
+          {errors.Gender?.message && <p>{errors.Gender.message}</p>}
 
           <label htmlFor="Allergies" className="form-label">Allergies:</label>
           <input type="text" id="Allergies" {...register('Allergies')} className="form-control" />

--- a/src/components/Pages/ChildRegistration.js
+++ b/src/components/Pages/ChildRegistration.js
@@ -6,9 +6,14 @@ import { doc, updateDoc } from 'firebase/firestore';
 import { db } from '../../config/firestore';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { logger } from '../../Helpers/logger';
+import { joiResolver } from '@hookform/resolvers/joi';
+import { generateChildSchema } from '../../schemas/ChildSchema';
+import { GENDERS } from '../../Helpers/constants';
 
 const ChildRegistration = ({ setOpenState }) => {
-  const { register, handleSubmit, formState: { errors }, reset } = useForm();
+  const { register, handleSubmit, formState: { errors }, reset } = useForm({
+    resolver: joiResolver(generateChildSchema(true))
+  });
   const { currentUser, dbService } = useAuth();
   const queryClient = useQueryClient();
 
@@ -64,13 +69,13 @@ const ChildRegistration = ({ setOpenState }) => {
 
           <label htmlFor="DOB" className="form-label">DOB:</label>
           <input type="date" id="DOB" {...register('DOB', { required: true })} className="form-control" />
-          {errors.DOB && <p>DOB is required</p>}
+          {errors.DOB?.message && <p>{errors.DOB.message}</p>}
 
           <label htmlFor="Gender" className="form-label">Gender:</label>
           <select id="Gender" {...register('Gender', { required: true })} className="form-control">
-            <option value="male">Male</option>
-            <option value="female">Female</option>
-            <option value="other">Unspecified</option>
+            {Object.values(GENDERS).map(option => {
+              return <option key={option} value={option}>{option}</option>;
+            })}
           </select>
           {errors.Gender && <p>Gender is required</p>}
 
@@ -89,5 +94,7 @@ const ChildRegistration = ({ setOpenState }) => {
     </div>
   );
 };
+
+ChildRegistration.whyDidYouRender = true; // Enable React's why-did-you-render for this component
 
 export default ChildRegistration;

--- a/src/components/Pages/ChildRegistration.js
+++ b/src/components/Pages/ChildRegistration.js
@@ -45,7 +45,7 @@ const ChildRegistration = ({ setOpenState }) => {
   const onSubmit = async (data) => {
     const payload = {
       ...data,
-      archived: true,
+      archived: false,
     }
 
     try {

--- a/src/components/Pages/ChildRegistration.js
+++ b/src/components/Pages/ChildRegistration.js
@@ -62,7 +62,6 @@ const ChildRegistration = ({ setOpenState }) => {
     } catch (error) {
       if (error.isJoi) {
         logger.error('Child registration failed validation:', error.details);
-        logger.error('Child registration error details:', error.details);
       }
       logger.error('Error adding document: ', error);
     }

--- a/src/components/Pages/ScheduleChildSitterPage.js
+++ b/src/components/Pages/ScheduleChildSitterPage.js
@@ -103,7 +103,7 @@ const ScheduleChildSitterPage = () => {
   }, [events, dbService, reservationTimeChangeMutation]);
 
 
-  const reservationArchiveChangeMutation = useMutation({
+  const archiveReservationMutation = useMutation({
     mutationFn: async (eventId) => dbService.archiveReservationDocument(eventId),
     onSuccess: () => {
       queryClient.invalidateQueries(
@@ -121,9 +121,9 @@ const ScheduleChildSitterPage = () => {
     const belongsToCurrentUser = children.some(child => child.id === event.extendedProps.childId);
 
     if (currentUser.Role === 'admin' || (belongsToCurrentUser && window.confirm(`Are you sure you want to remove the event: ${event.title}?`))) {
-      reservationArchiveChangeMutation.mutate(event.id);
+      archiveReservationMutation.mutate(event.id);
     }
-  }, [children, currentUser, reservationArchiveChangeMutation]);
+  }, [children, currentUser, archiveReservationMutation]);
 
   // Enforce rules for where events can be dropped or resized
   const eventAllow = useCallback((dropInfo) => {

--- a/src/components/Pages/ScheduleChildSitterPage.js
+++ b/src/components/Pages/ScheduleChildSitterPage.js
@@ -10,10 +10,14 @@ import ReservationFormModal from '../Shared/ReservationFormModal';
 import { BUSINESS_HRS, MIN_RESERVATION_DURATION_MS } from '../../Helpers/constants';
 import { useReservationsByMonthDayRQ } from '../../Hooks/query-related/useReservationsByMonthDayRQ';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { logger } from '../../Helpers/logger';
+import { LOG_LEVELS, logger, setLogLevel } from '../../Helpers/logger';
+import { luxonDateTimeFromISOString, luxonDateTimeFromJSDate } from '../../Helpers/datetime';
+import { DateTime } from 'luxon';
+
+setLogLevel(LOG_LEVELS.DEBUG); // Set log level to 'info' for debugging
 
 const ScheduleChildSitterPage = () => {
-  const [selectedDate, setSelectedDate] = useState(new Date());
+  const [selectedDate, setSelectedDate] = useState(DateTime.now());
   const queryClient = useQueryClient();
   const [children, setChildren] = useState([]);
   const { currentUser, dbService } = useAuth();
@@ -35,12 +39,12 @@ const ScheduleChildSitterPage = () => {
   }, [events]);
 
   const getViewDates = useCallback((args) => {
-    setSelectedDate(args.start);
+    setSelectedDate(luxonDateTimeFromISOString(args.startStr));
     setMonthYear({
-      day: args.start.getDate(),
+      day: luxonDateTimeFromISOString(args.startStr).day,
       week: args.view.type === 'timeGridWeek',
-      month: args.start.getMonth(),
-      year: args.start.getFullYear()
+      month: luxonDateTimeFromISOString(args.startStr).month - 1, // FullCalendar months are 0-indexed
+      year: luxonDateTimeFromISOString(args.startStr).year
     })
   }, []);
 
@@ -48,10 +52,10 @@ const ScheduleChildSitterPage = () => {
     mutationFn: async ({ id, newStart, newEnd }) => dbService.changeReservationTime(id, newStart, newEnd),
     onSuccess: () => {
       queryClient.invalidateQueries(
-        ['adminCalendarReservationsByWeek'],
-        selectedDate.getUTCDate(),
-        selectedDate.getUTCMonth(),
-        selectedDate.getUTCFullYear()
+        ['calendarReservationsByWeek'],
+        selectedDate.toUTC().day,
+        selectedDate.toUTC().month - 1,
+        selectedDate.toUTC().year
       )
     },
     onError: (err) => console.error("Error changing reservation time: ", err)
@@ -107,7 +111,7 @@ const ScheduleChildSitterPage = () => {
     mutationFn: async (eventId) => dbService.archiveReservationDocument(eventId),
     onSuccess: () => {
       queryClient.invalidateQueries(
-        ['adminCalendarReservationsByWeek'],
+        ['calendarReservationsByWeek'],
         selectedDate.getUTCDate(),
         selectedDate.getUTCMonth(),
         selectedDate.getUTCFullYear()
@@ -183,5 +187,5 @@ const ScheduleChildSitterPage = () => {
     </Grid>
   );
 };
-
+// ScheduleChildSitterPage.whyDidYouRender = true; // Enable for debugging purposes
 export default ScheduleChildSitterPage;

--- a/src/components/Shared/ChildCard.js
+++ b/src/components/Shared/ChildCard.js
@@ -10,9 +10,9 @@ function ChildCard({ child, onNameClick }) {
 
   const getAvatarImgName = () => {
     switch (child.Gender) {
-      case 'male':
+      case 'Male':
         return 'boy_avatar.png';
-      case 'female':
+      case 'Female':
         return 'girl_avatar.png';
       default:
         return 'green_avatar.png';

--- a/src/components/Shared/DashboardCalendar.js
+++ b/src/components/Shared/DashboardCalendar.js
@@ -7,6 +7,7 @@ import ChipBadge from './ChipBadge';
 import { useAdminPanelContext } from '../Dashboard/AdminPanelContext';
 import { useReservationsByMonthDayRQ } from '../../Hooks/query-related/useReservationsByMonthDayRQ';
 import { BUSINESS_HRS } from '../../Helpers/constants';
+import { isEventOnCalendarDay } from '../../Helpers/datetime';
 
 const DashboardCalendar = () => {
   const { setSelectedDate } = useAdminPanelContext();
@@ -33,7 +34,7 @@ const DashboardCalendar = () => {
 
   const renderDayContent = useCallback((dayCellInfo) => {
     const dayEvents = reservations.filter((event) => {
-      return event.start.getDate() === dayCellInfo.date.getDate();
+      return isEventOnCalendarDay(event.start, dayCellInfo.date);
     })
 
     const pendingEvents = dayEvents.filter((event) => {

--- a/src/components/Shared/UserForm.js
+++ b/src/components/Shared/UserForm.js
@@ -8,9 +8,13 @@ import { logger, setLogLevel, LOG_LEVELS } from "../../Helpers/logger";
 import ChangePasswordForm from "../ChangePasswordForm";
 import { useMutation } from "@tanstack/react-query";
 import { FirebaseDbService } from "../../Helpers/firebase";
+import { joiResolver } from "@hookform/resolvers/joi";
+import { generateUserProfileSchema } from "../../schemas/UserProfileSchema";
 
 const UserForm = () => {
-  const { register, handleSubmit, formState: { errors }, reset } = useForm();
+  const { register, handleSubmit, formState: { errors }, reset } = useForm({
+    resolver: joiResolver(generateUserProfileSchema(true)),
+  });
   const { currentUser } = useAuth();
   const [dbService, setDbService] = useState(null);
   const [email, setEmail] = React.useState(currentUser ? currentUser.Email : '');
@@ -59,7 +63,7 @@ const UserForm = () => {
     }
   })
 
-  const createUser = async (e) => {
+  const createUserOnSubmit = async (e) => {
     e.preventDefault();
     if (password !== confirm) {
       setPasswordMismatch(true);
@@ -93,7 +97,7 @@ const UserForm = () => {
     }
   })
 
-  const onSubmit = async (data) => {
+  const updateUserOnSubmit = async (data) => {
     // Remove the image from the data object
     const userImage = data.Image[0];
     delete data.Image;
@@ -103,10 +107,9 @@ const UserForm = () => {
     const dataWithoutPassword = { ...data };
     delete dataWithoutPassword.Password;
 
-    logger.info('Submit Mode:', mode); 
     try {
-      logger.info('Form Data:', data);
-      updateUserMutation.mutate(dataWithoutPassword, userImage);
+      const validatedFormData = await generateUserProfileSchema().validateAsync(dataWithoutPassword);
+      updateUserMutation.mutate(validatedFormData, userImage);
     } catch (e) {
       logger.error('Error adding/updating document: ', e.message);
       logger.error('Stack Trace:', e.stack);
@@ -118,59 +121,65 @@ const UserForm = () => {
     <div className="container" style={{}}>
       <div className="row justify-content-center">
         <div className="col register-form">
-          {(mode === "create") && <form onSubmit={createUser} className="row">
-            <div className="mb-3 col-12 col-md-6">
-              <label htmlFor="email" className="form-label">Email:</label>
-              <input className="form-control"
-                type="email"
-                id="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                required
-              />
-            </div>
-            <div className="mb-3 col-12 col-md-6">
-              <label htmlFor="password" className="form-label">Password:</label>
-              <input className="form-control"
-                type="password"
-                id="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
-              />
-            </div>
-            <div>
-              <label htmlFor="confirm" className="form-label">Confirm Password:</label>
-              <input className="form-control"
-                type="password"
-                id="confirm"
-                value={confirm}
-                onChange={(e) => setConfirm(e.target.value)}
-                required
-              />
-            </div>
-            {passwordMismatch && <p>Passwords do not match</p>}
-            {error && <p className="mt-3">{error}</p>}
-            <div className="row ">
-              <div className="col-12 col-md-6 mt-3"> <button type="submit" className="register-btn w-100">Sign Up</button></div>
-              <div className="col-12 col-md-6 mt-3"> <button onClick={signInWithGoogle} className="google-btn w-100" type="button">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" className="bi bi-google" viewBox="0 0 16 16">
-                      <path d="M15.545 6.558a9.42 9.42 0 0 1 .139 1.626c0 2.434-.87 4.492-2.384 5.885h.002C11.978 15.292 10.158 16 8 16A8 8 0 1 1 8 0a7.689 7.689 0 0 1 5.352 2.082l-2.284 2.284A4.347 4.347 0 0 0 8 3.166c-2.087 0-3.86 1.408-4.492 3.304a4.792 4.792 0 0 0 0 3.063h.003c.635 1.893 2.405 3.301 4.492 3.301 1.078 0 2.004-.276 2.722-.764h-.003a3.702 3.702 0 0 0 1.599-2.431H8v-3.08h7.545z" />
-                    </svg>
-                    <span className="ms-2">Sign up with Google</span>
-                  </button></div>
-            </div>
-            <div className="d-flex justify-content-center">
-             
-              
-            </div>
-          </form>}
+
+          {/* Create User Form */}
+          {(mode === "create") &&
+            <form onSubmit={createUserOnSubmit} className="row">
+              <div className="mb-3 col-12 col-md-6">
+                <label htmlFor="email" className="form-label">Email:</label>
+                <input className="form-control"
+                  type="email"
+                  id="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="mb-3 col-12 col-md-6">
+                <label htmlFor="password" className="form-label">Password:</label>
+                <input className="form-control"
+                  type="password"
+                  id="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
+                />
+              </div>
+              <div>
+                <label htmlFor="confirm" className="form-label">Confirm Password:</label>
+                <input className="form-control"
+                  type="password"
+                  id="confirm"
+                  value={confirm}
+                  onChange={(e) => setConfirm(e.target.value)}
+                  required
+                />
+              </div>
+              {passwordMismatch && <p>Passwords do not match</p>}
+              {error && <p className="mt-3">{error}</p>}
+              <div className="row ">
+                <div className="col-12 col-md-6 mt-3"> <button type="submit" className="register-btn w-100">Sign Up</button></div>
+                <div className="col-12 col-md-6 mt-3"> <button onClick={signInWithGoogle} className="google-btn w-100" type="button">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" className="bi bi-google" viewBox="0 0 16 16">
+                    <path d="M15.545 6.558a9.42 9.42 0 0 1 .139 1.626c0 2.434-.87 4.492-2.384 5.885h.002C11.978 15.292 10.158 16 8 16A8 8 0 1 1 8 0a7.689 7.689 0 0 1 5.352 2.082l-2.284 2.284A4.347 4.347 0 0 0 8 3.166c-2.087 0-3.86 1.408-4.492 3.304a4.792 4.792 0 0 0 0 3.063h.003c.635 1.893 2.405 3.301 4.492 3.301 1.078 0 2.004-.276 2.722-.764h-.003a3.702 3.702 0 0 0 1.599-2.431H8v-3.08h7.545z" />
+                  </svg>
+                  <span className="ms-2">Sign up with Google</span>
+                </button></div>
+              </div>
+              <div className="d-flex justify-content-center">
+
+
+              </div>
+            </form>
+          }
+
+          {/* Update User Form */}
           {(mode === "update") && (
-            <form onSubmit={handleSubmit(onSubmit)} className="row">
+            <form onSubmit={handleSubmit(updateUserOnSubmit)} className="row">
               <div className="mb-3">
                 <label htmlFor="Name" className="form-label">Name *</label>
-                <input type="text" className="form-control" {...register("Name", { required: "Name is required" })} />
-                {errors.Name && <div className="">{errors.Name.message}</div>}
+                <input type="text" className="form-control" {...register("Name")} />
+                {errors.Name?.message && <div className="">{errors.Name.message}</div>}
               </div>
               <div className="mb-3">
                 <label htmlFor="Email" className="form-label">Email</label>
@@ -180,21 +189,8 @@ const UserForm = () => {
                   disabled={mode === 'update'}
                   {...register("Email")}
                 />
-                {errors.Email && <p>{errors.Email.message}</p>}
+                {errors.Email?.message && <p>{errors.Email.message}</p>}
               </div>
-
-              {/* {mode === 'create' && (
-            <div className="mb-3">
-              <label htmlFor="Password" className="form-label">Password</label>
-              <input
-                className="form-control"
-                type="Password"
-                {...register("Password", { required: "Password is required" })}
-                disabled={mode === 'update'}
-              />
-              {errors.Password && <p>{errors.Password.message}</p>}
-            </div>
-          )} */}
               <div className="col-10 mb-3">
                 <label htmlFor="Image" className="form-label">Photo</label>
                 <input
@@ -202,17 +198,16 @@ const UserForm = () => {
                   {...register("Image")}
                   className="form-control"
                 />
-                {errors.Image && <p>{errors.Image.message}</p>}
+                {errors.Image?.message && <p>{errors.Image.message}</p>}
               </div>
-              {/* <div className="col-6"></div> */}
               <div className="mb-3  col-4">
                 <label htmlFor="CellNumber" className="form-label">Cell #</label>
                 <input
                   className="form-control"
                   type="text"
-                  {...register("CellNumber", { required: "Cell is required" })}
+                  {...register("CellNumber")}
                 />
-                {errors.CellNumber && <p>{errors.CellNumber.message}</p>}
+                {errors.CellNumber?.message && <p>{errors.CellNumber.message}</p>}
               </div>
 
               <div className="mb-3 col-6">
@@ -220,36 +215,36 @@ const UserForm = () => {
                 <input
                   className="form-control"
                   type="text"
-                  {...register("StreetAddress", { required: "Street Address is required" })}
+                  {...register("StreetAddress")}
                 />
-                {errors.StreetAddress && <p>{errors.StreetAddress.message}</p>}
+                {errors.StreetAddress?.message && <p>{errors.StreetAddress.message}</p>}
               </div>
               <div className="mb-3 col-4">
                 <label htmlFor="City" className="form-label">City</label>
                 <input
                   className="form-control"
                   type="text"
-                  {...register("City", { required: "City is required" })}
+                  {...register("City")}
                 />
-                {errors.City && <p>{errors.City.message}</p>}
+                {errors.City?.message && <p>{errors.City.message}</p>}
               </div>
               <div className="mb-3 col-4">
                 <label htmlFor="State" className="form-label">State</label>
                 <input
                   className="form-control"
                   type="text"
-                  {...register("State", { required: "State is required" })}
+                  {...register("State")}
                 />
-                {errors.State && <p>{errors.State.message}</p>}
+                {errors.State?.message && <p>{errors.State.message}</p>}
               </div>
               <div className="mb-3 col-2">
                 <label htmlFor="Zip" className="form-label">Zip</label>
                 <input
                   className="form-control"
                   type="text"
-                  {...register("Zip", { required: "Zip is required" })}
+                  {...register("Zip")}
                 />
-                {errors.Zip && <p>{errors.Zip.message}</p>}
+                {errors.Zip?.message && <p>{errors.Zip.message}</p>}
               </div>
               <div className="col-12">
                 <button type="submit" className="btn btn-primary mt-5  register-start">{mode === 'create' ? "Create" : "Update"} User</button></div>

--- a/src/schemas/ChildSchema.js
+++ b/src/schemas/ChildSchema.js
@@ -18,7 +18,8 @@ export const generateChildSchema = (forFormValidation = false) => {
                 .max(twoYearsAgo())
                 .required()
                 .messages({
-                  'date.max': 'Child must be at least 2 years old.'
+                  'date.max': `Child must be at least ${MIN_AGE_FOR_CHILD_YEARS} years old.`,
+                  'date.base': 'Invalid date format. Please use YYYY/MM/DD.'
                 }),
     Gender: Joi.string()
                 .valid(...Object.values(GENDERS))
@@ -26,7 +27,12 @@ export const generateChildSchema = (forFormValidation = false) => {
     Medications: Joi.string().allow('').optional(),
     Allergies: Joi.string().allow('').optional(),
     Notes: Joi.string().allow('').optional(),
-  }).prefs({ abortEarly: false })
+  })
+    .prefs({ abortEarly: false })
+    .messages({
+      'any.required': 'This field is required.',
+      'string.empty': 'This field is required.',
+    })
 
   if (forFormValidation) {
     schema = schema.fork(['archived'], (field) => field.forbidden());

--- a/src/schemas/ChildSchema.js
+++ b/src/schemas/ChildSchema.js
@@ -1,0 +1,35 @@
+import Joi from 'joi';
+import { GENDERS } from '../Helpers/constants';
+
+function twoYearsAgo() {
+  const date = new Date();
+  date.setFullYear(date.getFullYear() - 2);
+  return date;
+}
+
+export const generateChildSchema = (forFormValidation = false) => {
+  let schema = Joi.object({
+    // Administrative fields
+    archived: Joi.boolean().default(false).required(),
+    
+    // Child profile fields
+    Name: Joi.string().required(),
+    DOB: Joi.date()
+                .max(twoYearsAgo())
+                .required()
+                .messages({
+                  'date.max': 'Child must be at least 2 years old.'
+                }),
+    Gender: Joi.string()
+                .valid(...Object.values(GENDERS))
+                .required(),
+    Medications: Joi.string().allow('').optional(),
+    Allergies: Joi.string().allow('').optional(),
+    Notes: Joi.string().allow('').optional(),
+  }).prefs({ abortEarly: false })
+
+  if (forFormValidation) {
+    schema = schema.fork(['archived'], (field) => field.forbidden());
+  }
+  return schema;
+} 

--- a/src/schemas/ChildSchema.js
+++ b/src/schemas/ChildSchema.js
@@ -1,9 +1,9 @@
 import Joi from 'joi';
-import { GENDERS } from '../Helpers/constants';
+import { GENDERS, MIN_AGE_FOR_CHILD_YEARS } from '../Helpers/constants';
 
 function twoYearsAgo() {
   const date = new Date();
-  date.setFullYear(date.getFullYear() - 2);
+  date.setFullYear(date.getFullYear() - MIN_AGE_FOR_CHILD_YEARS);
   return date;
 }
 

--- a/src/schemas/ContactSchema.js
+++ b/src/schemas/ContactSchema.js
@@ -1,0 +1,65 @@
+import Joi from "joi"
+import { CONTACT_RELATIONS } from "../Helpers/constants";
+export const generateContactSchema = (forFormValidation = false) => {
+  let schema = Joi.object({
+    // Administrative fields
+    archived: Joi.boolean().default(false).required(),
+
+    // Form-set fields
+    Name: Joi.string().min(3).required(),
+    Phone: Joi.any()
+      .custom((value, helpers) => {
+        if (value === '' || value === undefined) return undefined;
+        if (typeof value !== 'string') {
+          return helpers.error('phone.base');
+        }
+        const phoneRegex = /^\d{3}-\d{3}-\d{4}$/;
+        if (!phoneRegex.test(value)) {
+          return helpers.error('phone.badFormat');
+        }
+        return value;
+      })
+      .optional()
+      .messages({
+        'phone.base': 'Phone # must be a string.',
+        'phone.badFormat': 'Phone # must be in the format "123-456-7890".'
+      }),
+    Email: Joi.any()
+      .custom((value, helpers) => {
+        if (value === '' || value === undefined) return undefined;
+        if (typeof value !== 'string') {
+          return helpers.error('email.base');
+        }
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if (!emailRegex.test(value)) {
+          return helpers.error('email.badFormat');
+        }
+        return value;
+      })
+      .optional()
+      .messages({
+        'email.base': 'Email must be a string.',
+        'email.badFormat': 'Email address format is invalid.'
+      }),
+    Relation: Joi.string()
+      .valid(...Object.values(CONTACT_RELATIONS))
+      .required()
+      .messages({
+        'any.only': "Provided relation is not valid."
+      }),
+  })
+    .or('Phone', 'Email')                                                 // At least one of Phone or Email must be provided
+    .messages({
+      'object.missing': 'At least one of Phone or Email must be provided.',
+    })
+    .prefs({ abortEarly: false })
+
+
+  if (forFormValidation) {
+    // If this schema is used for form validation, we don't want to allow
+    // fields that are not relevant to the form submission.
+    schema = schema.fork(['archived'], (field) => field.forbidden());
+  }
+
+  return schema;
+}

--- a/src/schemas/ReservationSchema.js
+++ b/src/schemas/ReservationSchema.js
@@ -1,0 +1,25 @@
+import Joi from 'joi';
+import { RESERVATION_STATUS } from '../Helpers/constants';
+import { DocumentReference } from 'firebase/firestore';
+
+const ReservationSchema = Joi.object({
+  // Administrative fields
+  archived: Joi.boolean().required(),
+  billingLocked: Joi.boolean().required(),
+  allDay: Joi.boolean().required(),
+  overrideTotalCents: Joi.number().integer().min(0).optional(),       // Optional field for overriding total billing amount
+  
+  // Reservation fields
+  start: Joi.date().required(),
+  end: Joi.date().required(),
+  title: Joi.string().required(),
+  extendedProps: Joi.object({
+    status: Joi.string()
+                .valid(...Object.values(RESERVATION_STATUS))
+                .required(),
+    childId: Joi.string().required(),
+  }),
+  userId: Joi.string().required(),
+  Child: Joi.object().instance(DocumentReference).required(),
+  User: Joi.object().instance(DocumentReference).required(),
+})

--- a/src/schemas/ReservationSchema.js
+++ b/src/schemas/ReservationSchema.js
@@ -1,25 +1,38 @@
 import Joi from 'joi';
 import { RESERVATION_STATUS } from '../Helpers/constants';
-import { DocumentReference } from 'firebase/firestore';
+import { DocumentReference, Timestamp } from 'firebase/firestore';
 
 const ReservationSchema = Joi.object({
   // Administrative fields
   archived: Joi.boolean().default(false).required(),
-  billingLocked: Joi.boolean().required(),
-  allDay: Joi.boolean().required(),
+  billingLocked: Joi.boolean().default(false).required(),
+  allDay: Joi.boolean().default(false).required(),                    // TODO: Remove all references to this field
   overrideTotalCents: Joi.number().integer().min(0).optional(),       // Optional field for overriding total billing amount
-  
+
   // Reservation fields
-  start: Joi.date().required(),
-  end: Joi.date().required(),
+  start: Joi.object().instance(Timestamp).required().messages({
+    'object.instance': 'Start time must be a valid Timestamp object.'
+  }),
+  end: Joi.object().instance(Timestamp).required().messages({
+    'object.instance': 'End time must be a valid Timestamp object.'
+  }),
   title: Joi.string().required(),
   extendedProps: Joi.object({
     status: Joi.string()
-                .valid(...Object.values(RESERVATION_STATUS))
-                .required(),
+      .valid(...Object.values(RESERVATION_STATUS))
+      .required(),
     childId: Joi.string().required(),
+    duration: Joi.number().min(0).optional(),                           // TODO: Does this field serve a purpose?
   }),
   userId: Joi.string().required(),
-  Child: Joi.object().instance(DocumentReference).required(),
-  User: Joi.object().instance(DocumentReference).required(),
+  Child: Joi.object().instance(DocumentReference).required().messages({
+    'object.instance': 'Child must be a valid DocumentReference.'
+  }),
+  User: Joi.object().instance(DocumentReference).required().messages({
+    'object.instance': 'User must be a valid DocumentReference.'
+  }),
+  groupActivity: Joi.boolean().default(false).optional(),
 })
+  .prefs({ abortEarly: false });
+
+export default ReservationSchema;

--- a/src/schemas/ReservationSchema.js
+++ b/src/schemas/ReservationSchema.js
@@ -4,7 +4,7 @@ import { DocumentReference } from 'firebase/firestore';
 
 const ReservationSchema = Joi.object({
   // Administrative fields
-  archived: Joi.boolean().required(),
+  archived: Joi.boolean().default(false).required(),
   billingLocked: Joi.boolean().required(),
   allDay: Joi.boolean().required(),
   overrideTotalCents: Joi.number().integer().min(0).optional(),       // Optional field for overriding total billing amount

--- a/src/schemas/UserProfileSchema.js
+++ b/src/schemas/UserProfileSchema.js
@@ -1,0 +1,28 @@
+import Joi from 'joi';
+import { ROLES } from '../Helpers/constants';
+import { DocumentReference } from 'firebase/firestore';
+
+const UserProfileSchema = Joi.object({
+  // Administrative fields
+  archived: Joi.boolean().required(),
+  paymentHold: Joi.boolean().required(),
+
+  // User profile fields
+  CellNumber: Joi.string().required(),
+  City: Joi.string().required(),
+  Email: Joi.string().email().required(),
+  Name: Joi.string().required(),
+  Role: Joi.string().valid(...Object.values(ROLES)).required(),
+  State: Joi.string().required(),
+  StreetAddress: Joi.string().required(),
+  Zip: Joi.string().required(),
+
+  // Optional fields
+  Children: Joi.array()
+                .items(Joi.object().instance(DocumentReference))
+                .optional(),
+  Contacts: Joi.array()
+                .items(Joi.object().instance(DocumentReference))
+                .optional(),
+  // ProfilePhoto field goes here and is a URL
+})

--- a/src/schemas/UserProfileSchema.js
+++ b/src/schemas/UserProfileSchema.js
@@ -2,27 +2,59 @@ import Joi from 'joi';
 import { ROLES } from '../Helpers/constants';
 import { DocumentReference } from 'firebase/firestore';
 
-const UserProfileSchema = Joi.object({
-  // Administrative fields
-  archived: Joi.boolean().default(false).required(),
-  paymentHold: Joi.boolean().required(),
+export const generateUserProfileSchema = (forFormValidation = false) => {
+  let schema = Joi.object({
+    // Administrative fields
+    archived: Joi.boolean().default(false).required(),
+    paymentHold: Joi.boolean().default(false).required(),
 
-  // User profile fields
-  CellNumber: Joi.string().required(),
-  City: Joi.string().required(),
-  Email: Joi.string().email().required(),
-  Name: Joi.string().required(),
-  Role: Joi.string().valid(...Object.values(ROLES)).required(),
-  State: Joi.string().required(),
-  StreetAddress: Joi.string().required(),
-  Zip: Joi.string().required(),
+    // Form-set fields
+    CellNumber: Joi.string().required(),
+    City: Joi.string().required(),
+    Email: Joi.string().email({
+        tlds: { allow: false }
+      }).required(),
+    Name: Joi.string().required(),
+    Role: Joi.string().valid(...Object.values(ROLES)).required()
+      .messages({
+      'any.only': "Provided role is not valid."
+      }),
+    State: Joi.string().default('NC').required(),
+    StreetAddress: Joi.string().required()
+      .messages({
+      'string.empty': 'Street address is required for billing and contact purposes.'
+      }),
+    Zip: Joi.string()
+      .pattern(/^\d{5}(-\d{4})?$/)
+      .required()
+      .messages({
+      'string.pattern.base': 'Format "12345" or "12345-6789".'
+      }),
 
-  // Optional fields
-  Children: Joi.array()
-                .items(Joi.object().instance(DocumentReference))
-                .optional(),
-  Contacts: Joi.array()
-                .items(Joi.object().instance(DocumentReference))
-                .optional(),
-  // ProfilePhoto field goes here and is a URL
-})
+    // Fields set programmatically
+    Children: Joi.array()
+      .items(Joi.object().instance(DocumentReference))
+      .optional(),
+    Contacts: Joi.array()
+      .items(Joi.object().instance(DocumentReference))
+      .optional(),
+    photoURL: Joi.string().uri().optional(),
+  })
+    .prefs({ abortEarly: false })
+    .messages({
+      'any.required': 'This field is required.',
+      'string.empty': 'This field is required.',
+      'string.email': 'Please provide a valid email address.',
+      'string.uri': 'Please provide a valid URL for the profile picture.'
+    });
+
+  // If this schema is used for form validation, we don't want to allow
+  // fields that are not relevant to the form submission.
+  if (forFormValidation) {
+    schema = schema.fork([
+      'archived', 'paymentHold', 'photoURL', 'Children', 'Contacts'
+    ], (field) => field.forbidden());
+  }
+
+  return schema;
+} 

--- a/src/schemas/UserProfileSchema.js
+++ b/src/schemas/UserProfileSchema.js
@@ -4,7 +4,7 @@ import { DocumentReference } from 'firebase/firestore';
 
 const UserProfileSchema = Joi.object({
   // Administrative fields
-  archived: Joi.boolean().required(),
+  archived: Joi.boolean().default(false).required(),
   paymentHold: Joi.boolean().required(),
 
   // User profile fields


### PR DESCRIPTION
In the process of building #45, I realized what a problem it would be that there is no data shape enforcement for Firebase data. This PR fulfills the following needs:

- Lightweight data validation at runtime without translating the entire project to TS
- Explicitly defined valid schema for any data to be persisted into firestore
- Better form validation error messages right out of the box (stretch goal)