### PR TITLE
72 display list of bookings by day on admin dashboard

### DIFF
--- a/src/Helpers/calendar.js
+++ b/src/Helpers/calendar.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import  StyledCalendarEvent from '../components/Shared/StyledCalendarEvent';
+import AggregateTimeSlot from '../components/Shared/AggregateTimeSlot';
 import { BUSINESS_HRS } from './constants';
 
 
@@ -23,8 +24,17 @@ export function checkFutureStartTime(event) {
 
 export const renderEventContent = (eventInfo) => {
   const { event } = eventInfo;
+  
+  // Handle aggregate events (confirmed appointments grouped into 15-minute slots)
+  if (event.extendedProps?.isAggregate) {
+    // Muted neon purple color for aggregate events
+    const backgroundColor = '#8A2BE2'; // BlueViolet - muted neon purple
+    return <AggregateTimeSlot event={event} backgroundColor={backgroundColor} />;
+  }
+  
+  // Handle individual events (pending appointments and other statuses)
   let backgroundColor;
-  switch (event.extendedProps.status) {
+  switch (event.status) {
     case 'confirmed':
       backgroundColor = 'mediumseagreen';
       break;

--- a/src/Helpers/timeSlotAggregates.js
+++ b/src/Helpers/timeSlotAggregates.js
@@ -1,0 +1,100 @@
+import { BUSINESS_HRS } from './constants';
+
+/**
+ * Generates 15-minute time slot aggregates for confirmed appointments
+ * 
+ * @param {Array} confirmedAppointments - Array of confirmed appointment events
+ * @returns {Array} Array of aggregate events for FullCalendar
+ */
+export function generateTimeSlotAggregates(confirmedAppointments) {
+  if (!confirmedAppointments || confirmedAppointments.length === 0) {
+    return [];
+  }
+
+  // Group appointments by 15-minute time slots
+  const slotMap = new Map();
+  
+  // Generate all possible 15-minute slots within business hours
+  const businessStartHour = parseInt(BUSINESS_HRS.startTime.split(':')[0]);
+  const businessEndHour = parseInt(BUSINESS_HRS.endTime.split(':')[0]);
+  
+  // Get unique dates from all appointments
+  const appointmentDates = [...new Set(confirmedAppointments.map(apt => {
+    const date = new Date(apt.start);
+    return date.toDateString();
+  }))];
+  
+  // Create slots for each unique date
+  appointmentDates.forEach(dateString => {
+    const targetDate = new Date(dateString);
+    
+    // Create slots for each hour in business hours on this date
+    for (let hour = businessStartHour; hour < businessEndHour; hour++) {
+      const slots = ['00', '15', '30', '45'];
+      
+      slots.forEach(minutes => {
+        const slotStart = new Date(targetDate);
+        slotStart.setHours(hour, parseInt(minutes), 0, 0);
+        const slotEnd = new Date(slotStart);
+        slotEnd.setMinutes(slotEnd.getMinutes() + 15);
+        
+        const slotKey = `${dateString}-${hour.toString().padStart(2, '0')}:${minutes}`;
+        slotMap.set(slotKey, {
+          start: slotStart,
+          end: slotEnd,
+          appointments: []
+        });
+      });
+    }
+  });
+  
+  // Count appointments in each slot
+  confirmedAppointments.forEach((appointment, index) => {
+    // Use the original string dates to preserve timezone information
+    const apptStart = new Date(appointment.start);
+    const apptEnd = new Date(appointment.end);
+    
+    slotMap.forEach((slot, slotKey) => {
+      if (shouldCountAppointmentInSlot(apptStart, apptEnd, slot.start, slot.end)) {
+        slot.appointments.push(appointment);
+      }
+    });
+  });
+  
+  // Convert slots with appointments to aggregate events
+  const aggregates = [];
+  slotMap.forEach((slot, slotKey) => {
+    if (slot.appointments.length > 0) {
+      const aggregateEvent = {
+        id: `aggregate-${slotKey}`,
+        title: `${slot.appointments.length} appointment${slot.appointments.length === 1 ? '' : 's'}`,
+        start: slot.start.toISOString(),
+        end: slot.end.toISOString(),
+        extendedProps: {
+          isAggregate: true,
+          appointmentIds: slot.appointments.map(apt => apt.id),
+          count: slot.appointments.length,
+          appointments: slot.appointments // Store full appointment data for future use
+        }
+      };
+      aggregates.push(aggregateEvent);
+    }
+  });
+  
+  return aggregates;
+}
+
+/**
+ * Determines if an appointment should be counted in a specific time slot
+ * 
+ * @param {Date} apptStart - Appointment start time
+ * @param {Date} apptEnd - Appointment end time
+ * @param {Date} slotStart - Time slot start time
+ * @param {Date} slotEnd - Time slot end time
+ * @returns {boolean} True if appointment should be counted in this slot
+ */
+function shouldCountAppointmentInSlot(apptStart, apptEnd, slotStart, slotEnd) {
+  // Appointment must actively occupy the slot
+  // Excludes: appointment ends exactly at slot start OR starts exactly at slot end
+  return apptStart < slotEnd && apptEnd > slotStart;
+}

--- a/src/Hooks/query-related/useAllReservationsRQ.js
+++ b/src/Hooks/query-related/useAllReservationsRQ.js
@@ -46,8 +46,6 @@ export function useAllReservationsRQ({
   const dataQueryResult = useQuery({
     queryKey,
     queryFn: async () => {
-      console.log('Fetching page', page, 'with pageSize', pageSize);
-      
       // First, get all document IDs (lightweight)
       const allDocsSnapshot = await getDocs(baseQuery);
       const allDocIds = allDocsSnapshot.docs.map(doc => doc.id);
@@ -56,8 +54,6 @@ export function useAllReservationsRQ({
       const startIndex = (page - 1) * pageSize;
       const endIndex = startIndex + pageSize;
       const pageDocIds = allDocIds.slice(startIndex, endIndex);
-      
-      console.log(`Page ${page} of ${Math.ceil(allDocIds.length / pageSize)}: showing docs ${startIndex + 1}-${Math.min(endIndex, allDocIds.length)} of ${allDocIds.length} (${pageDocIds.length} docs on this page)`);
       
       // Fetch full documents for this page
       const pageDocs = [];

--- a/src/Hooks/query-related/useAllReservationsRQ.js
+++ b/src/Hooks/query-related/useAllReservationsRQ.js
@@ -1,0 +1,115 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "../../components/AuthProvider";
+import { useEffect, useMemo, useState } from "react";
+import { collection, query, where, orderBy, limit, getCountFromServer, getDocs } from "firebase/firestore";
+import { db } from "../../config/firestore";
+import { COLLECTIONS } from "../../Helpers/constants";
+
+export function useAllReservationsRQ({ 
+  enabled = true, 
+  page = 1, 
+  pageSize = 25 
+} = {}) {
+  const queryClient = useQueryClient();
+  const { dbService } = useAuth();
+  const [totalCount, setTotalCount] = useState(0);
+  
+  const queryKey = ['adminAllReservations', page, pageSize];
+
+  // Build the base query for count
+  const countQuery = useMemo(() => query(
+    collection(db, COLLECTIONS.RESERVATIONS),
+    where("archived", "!=", true)
+  ), []);
+
+  // Build the base query for getting all document IDs
+  const baseQuery = useMemo(() => query(
+    collection(db, COLLECTIONS.RESERVATIONS),
+    where("archived", "!=", true),
+    orderBy("start", "desc")
+  ), []);
+  
+  // Count query
+  const countQueryResult = useQuery({
+    queryKey: ['adminAllReservationsCount'],
+    queryFn: async () => {
+      const snapshot = await getCountFromServer(countQuery);
+      return snapshot.data().count;
+    },
+    enabled,
+    onError: (error) => {
+      console.error("Error fetching reservations count:", error);
+    },
+  });
+
+  // Data query - fetch all IDs first, then paginate and fetch full docs
+  const dataQueryResult = useQuery({
+    queryKey,
+    queryFn: async () => {
+      console.log('Fetching page', page, 'with pageSize', pageSize);
+      
+      // First, get all document IDs (lightweight)
+      const allDocsSnapshot = await getDocs(baseQuery);
+      const allDocIds = allDocsSnapshot.docs.map(doc => doc.id);
+      
+      // Calculate pagination
+      const startIndex = (page - 1) * pageSize;
+      const endIndex = startIndex + pageSize;
+      const pageDocIds = allDocIds.slice(startIndex, endIndex);
+      
+      console.log(`Page ${page} of ${Math.ceil(allDocIds.length / pageSize)}: showing docs ${startIndex + 1}-${Math.min(endIndex, allDocIds.length)} of ${allDocIds.length} (${pageDocIds.length} docs on this page)`);
+      
+      // Fetch full documents for this page
+      const pageDocs = [];
+      for (const docId of pageDocIds) {
+        const docSnapshot = allDocsSnapshot.docs.find(doc => doc.id === docId);
+        if (docSnapshot) {
+          pageDocs.push({ id: docSnapshot.id, ...docSnapshot.data() });
+        }
+      }
+      
+      return pageDocs;
+    },
+    enabled,
+    staleTime: 0, // Always consider data stale to force refetch
+    onError: (error) => {
+      console.error("Error fetching /Reservations data:", error);
+    },
+  });
+
+  // Update total count when count query completes
+  useEffect(() => {
+    if (countQueryResult.data !== undefined) {
+      setTotalCount(countQueryResult.data);
+    }
+  }, [countQueryResult.data]);
+
+
+  // Calculate pagination info
+  const totalPages = Math.ceil(totalCount / pageSize);
+  const hasNextPage = page < totalPages;
+  const hasPreviousPage = page > 1;
+
+  // Navigation functions
+  const goToPage = (newPage) => {
+    if (newPage >= 1 && newPage <= totalPages) {
+      // The component should update the page prop to trigger a new query
+      return newPage;
+    }
+    return page;
+  };
+
+
+  return {
+    data: dataQueryResult.data || [],
+    isLoading: dataQueryResult.isLoading || countQueryResult.isLoading,
+    isError: dataQueryResult.isError || countQueryResult.isError,
+    error: dataQueryResult.error || countQueryResult.error,
+    totalCount,
+    totalPages,
+    currentPage: page,
+    hasNextPage,
+    hasPreviousPage,
+    goToPage,
+  };
+}

--- a/src/Hooks/query-related/useAllReservationsRQ.js
+++ b/src/Hooks/query-related/useAllReservationsRQ.js
@@ -71,7 +71,7 @@ export function useAllReservationsRQ({
       return pageDocs;
     },
     enabled,
-    staleTime: 0, // Always consider data stale to force refetch
+    staleTime: 15000, // 15 seconds between refetches
     onError: (error) => {
       console.error("Error fetching /Reservations data:", error);
     },

--- a/src/Hooks/query-related/useReservationsByMonthDayRQ.js
+++ b/src/Hooks/query-related/useReservationsByMonthDayRQ.js
@@ -86,6 +86,7 @@ export function useReservationsByMonthDayRQ({ enabled = true } = {}) {
       status: res.extendedProps.status,
       childId: res.extendedProps.childId,
       title: res.title || "",
+      userId: res.userId, // Include userId field
       start: luxonDateTimeFromFirebaseTimestamp(res.start).toISO(),
       end: luxonDateTimeFromFirebaseTimestamp(res.end).toISO(),
       startDT: luxonDateTimeFromFirebaseTimestamp(res.start),

--- a/src/Hooks/query-related/useReservationsByMonthDayRQ.js
+++ b/src/Hooks/query-related/useReservationsByMonthDayRQ.js
@@ -8,7 +8,7 @@ import { logger } from "../../Helpers/logger";
 import _ from "lodash";
 import { luxonDateTimeFromFirebaseTimestamp } from "../../Helpers/datetime";
 
-export function useReservationsByMonthDayRQ() {
+export function useReservationsByMonthDayRQ({ enabled = true } = {}) {
   const { dbService, currentUser } = useAuth();
   const [monthYear, setMonthYearRaw] = useState({ day: null, week: false, month: new Date().getMonth(), year: new Date().getFullYear() });
   const queryClient = useQueryClient();
@@ -98,6 +98,7 @@ export function useReservationsByMonthDayRQ() {
     queryKey,
     queryFn: () => dbService.fetchDocs(reservationQuery, false),
     select: (data) => data.map(transformReservationData).filter(Boolean),
+    enabled,
     onError: (error) => {
       console.error("Error fetching monthly reservations:", error);
     },
@@ -110,11 +111,13 @@ export function useReservationsByMonthDayRQ() {
   );
 
   useEffect(() => {
+    if (!enabled) return;
+    
     const unsubscribe = dbService.subscribeDocs(reservationQuery, fresh => {
       queryClient.setQueryData(queryKey, fresh.map(transformReservationData).filter(Boolean)); 
     }, false);
     return () => unsubscribe();
-  }, [queryKey, reservationQuery, queryClient]);
+  }, [queryKey, reservationQuery, queryClient, enabled]);
 
   return {
     ...queryResult,

--- a/src/components/Dashboard/AdminCalendarInteractionColumn.js
+++ b/src/components/Dashboard/AdminCalendarInteractionColumn.js
@@ -14,7 +14,7 @@ export default function AdminCalendarInteractionColumn({ calHeight }) {
         style={{ maxHeight: calHeight, minHeight: calHeight }}
       >
         <InteractionColumnNavHeader>
-          {interactionColumnMode === 'notifications' ? <AdminDashNotificationsFeed /> : <ManageReservationsPage initialDateValue={selectedDate} contextDateSetter={setSelectedDate} />}
+          {interactionColumnMode === 'notifications' ? <AdminDashNotificationsFeed /> : <ManageReservationsPage initialDateValue={selectedDate} contextDateSetter={setSelectedDate} enableAggregates={true} />}
           
         </InteractionColumnNavHeader>
       </div>

--- a/src/components/Dashboard/AdminReservations.js
+++ b/src/components/Dashboard/AdminReservations.js
@@ -3,6 +3,28 @@ import { useAllReservationsRQ } from "../../Hooks/query-related/useAllReservatio
 import { useReservationsByMonthDayRQ } from "../../Hooks/query-related/useReservationsByMonthDayRQ";
 import { useAdminPanelContext } from "./AdminPanelContext";
 
+// Helper function to generate visible page numbers for pagination
+const generateVisiblePageNumbers = (currentPage, totalPages, maxVisiblePages = 5) => {
+  // If we have fewer pages than the maximum visible, show all pages
+  if (totalPages <= maxVisiblePages) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  }
+  
+  // Calculate the range of pages to show, centered around current page
+  const halfVisible = Math.floor(maxVisiblePages / 2);
+  let startPage = Math.max(1, currentPage - halfVisible);
+  let endPage = Math.min(totalPages, startPage + maxVisiblePages - 1);
+  
+  // Adjust start page if we're near the end
+  if (endPage - startPage < maxVisiblePages - 1) {
+    startPage = Math.max(1, endPage - maxVisiblePages + 1);
+  }
+  
+  return Array.from({ length: endPage - startPage + 1 }, (_, i) => startPage + i);
+};
+
+
+
 const AdminReservations = ({ selectedDate = null, showReturnButton = false, onReturnToMonth = null }) => {
   // Use conditional hook calls based on context
   const isDayView = selectedDate !== null;
@@ -281,22 +303,17 @@ const AdminReservations = ({ selectedDate = null, showReturnButton = false, onRe
                       </button>
                     </li>
                     
-                    {/* Show page numbers */}
-                    {Array.from({ length: Math.min(5, paginationInfo.totalPages) }, (_, i) => {
-                      const pageNum = Math.max(1, Math.min(paginationInfo.totalPages - 4, paginationInfo.currentPage - 2)) + i;
-                      if (pageNum > paginationInfo.totalPages) return null;
-                      
-                      return (
-                        <li key={pageNum} className={`page-item ${paginationInfo.currentPage === pageNum ? 'active' : ''}`}>
-                          <button 
-                            className="page-link" 
-                            onClick={() => setCurrentPage(pageNum)}
-                          >
-                            {pageNum}
-                          </button>
-                        </li>
-                      );
-                    })}
+                    {/* Show page numbers - display up to 5 pages centered around current page */}
+                    {generateVisiblePageNumbers(paginationInfo.currentPage, paginationInfo.totalPages).map(pageNum => (
+                      <li key={pageNum} className={`page-item ${paginationInfo.currentPage === pageNum ? 'active' : ''}`}>
+                        <button 
+                          className="page-link" 
+                          onClick={() => setCurrentPage(pageNum)}
+                        >
+                          {pageNum}
+                        </button>
+                      </li>
+                    ))}
                     
                     <li className={`page-item ${!paginationInfo.hasNextPage ? 'disabled' : ''}`}>
                       <button 

--- a/src/components/Dashboard/AdminReservations.js
+++ b/src/components/Dashboard/AdminReservations.js
@@ -1,0 +1,301 @@
+import React, { useState, useMemo } from "react";
+import { useAllReservationsRQ } from "../../Hooks/query-related/useAllReservationsRQ";
+import { useReservationsByMonthDayRQ } from "../../Hooks/query-related/useReservationsByMonthDayRQ";
+import { useAdminPanelContext } from "./AdminPanelContext";
+
+const AdminReservations = ({ selectedDate = null, showReturnButton = false, onReturnToMonth = null }) => {
+  // Use conditional hook calls based on context
+  const isDayView = selectedDate !== null;
+  const [currentPage, setCurrentPage] = useState(1);
+  const pageSize = 25;
+  
+  const allReservationsQuery = useAllReservationsRQ({ 
+    enabled: !isDayView, 
+    page: currentPage, 
+    pageSize 
+  });
+  const monthReservationsQuery = useReservationsByMonthDayRQ({ enabled: isDayView });
+  
+  // Use the appropriate query result
+  const queryResult = isDayView ? monthReservationsQuery : allReservationsQuery;
+  
+  // Extract data based on query type
+  const reservations = queryResult.data || [];
+  const isLoading = queryResult.isLoading;
+  const isError = queryResult.isError;
+  
+  // Extract pagination info for admin view
+  const paginationInfo = isDayView ? null : {
+    totalCount: allReservationsQuery.totalCount,
+    totalPages: allReservationsQuery.totalPages,
+    currentPage: allReservationsQuery.currentPage,
+    hasNextPage: allReservationsQuery.hasNextPage,
+    hasPreviousPage: allReservationsQuery.hasPreviousPage,
+    goToPage: (newPage) => {
+      setCurrentPage(newPage);
+    }
+  };
+
+  // Calculate the range of items being displayed
+  const getItemRange = () => {
+    if (isDayView) {
+      return { start: 1, end: filteredReservations.length, total: filteredReservations.length };
+    }
+    
+    if (paginationInfo) {
+      const start = (paginationInfo.currentPage - 1) * pageSize + 1;
+      const end = Math.min(paginationInfo.currentPage * pageSize, paginationInfo.totalCount);
+      return { start, end, total: paginationInfo.totalCount };
+    }
+    
+    return { start: 1, end: displayReservations.length, total: displayReservations.length };
+  };
+  
+  const [searchTerm, setSearchTerm] = useState("");
+  const [sortField, setSortField] = useState("start");
+  const [sortDirection, setSortDirection] = useState("desc");
+
+  // Filter reservations by selected date if provided
+  const filteredReservations = useMemo(() => {
+    let filtered = reservations;
+    
+    // Filter by date if selectedDate is provided
+    if (selectedDate) {
+      const startOfDay = new Date(selectedDate);
+      startOfDay.setHours(0, 0, 0, 0);
+      const endOfDay = new Date(selectedDate);
+      endOfDay.setHours(23, 59, 59, 999);
+      
+      filtered = filtered.filter(reservation => {
+        const reservationDate = new Date(reservation.start?.seconds ? reservation.start.toDate() : reservation.start);
+        return reservationDate >= startOfDay && reservationDate <= endOfDay;
+      });
+    }
+    
+    // Filter by search term
+    if (searchTerm) {
+      filtered = filtered.filter(reservation => 
+        reservation.title?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        reservation.extendedProps?.status?.toLowerCase().includes(searchTerm.toLowerCase())
+      );
+    }
+    
+    // Sort the results
+    filtered.sort((a, b) => {
+      let aValue, bValue;
+      
+      switch (sortField) {
+        case "start":
+          aValue = new Date(a.start?.seconds ? a.start.toDate() : a.start);
+          bValue = new Date(b.start?.seconds ? b.start.toDate() : b.start);
+          break;
+        case "title":
+          aValue = a.title || "";
+          bValue = b.title || "";
+          break;
+        case "status":
+          aValue = a.extendedProps?.status || "";
+          bValue = b.extendedProps?.status || "";
+          break;
+        default:
+          aValue = a[sortField] || "";
+          bValue = b[sortField] || "";
+      }
+      
+      if (sortDirection === "asc") {
+        return aValue > bValue ? 1 : -1;
+      } else {
+        return aValue < bValue ? 1 : -1;
+      }
+    });
+    
+    return filtered;
+  }, [reservations, selectedDate, searchTerm, sortField, sortDirection]);
+
+  // For now, use filteredReservations directly (pagination will be handled by the hook)
+  const displayReservations = filteredReservations;
+
+  const handleSort = (field) => {
+    if (sortField === field) {
+      setSortDirection(sortDirection === "asc" ? "desc" : "asc");
+    } else {
+      setSortField(field);
+      setSortDirection("asc");
+    }
+  };
+
+  const formatDate = (timestamp) => {
+    if (!timestamp) return '--';
+    const date = timestamp.seconds ? new Date(timestamp.toDate()) : new Date(timestamp);
+    return date.toLocaleDateString();
+  };
+
+  const formatTime = (timestamp) => {
+    if (!timestamp) return '--';
+    const date = timestamp.seconds ? new Date(timestamp.toDate()) : new Date(timestamp);
+    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  };
+
+  const formatTableRow = (reservation) => {
+    return (
+      <tr key={reservation.id}>
+        <th scope="row">{reservation.title || '--'}</th>
+        <td>{formatDate(reservation.start)}</td>
+        <td>{formatTime(reservation.start)} - {formatTime(reservation.end)}</td>
+        <td>{reservation.extendedProps?.status || '--'}</td>
+        <td>{reservation.extendedProps?.childId || '--'}</td>
+        <td>{reservation.userId || '--'}</td>
+      </tr>
+    )
+  }
+
+  const getSortIcon = (field) => {
+    if (sortField !== field) return "↕️";
+    return sortDirection === "asc" ? "↑" : "↓";
+  };
+
+  const cardTitle = selectedDate 
+    ? `Appointments for ${formatDate(selectedDate)}`
+    : "All Appointments";
+
+  return (
+    <>
+      <div className="row">
+        <div className="col-12 mb-4 mb-lg-0">
+          <div className="card">
+            <div className="card-header d-flex justify-content-between align-items-center">
+              <h5 className="mb-0">{cardTitle}</h5>
+              {showReturnButton && onReturnToMonth && (
+                <button 
+                  className="btn btn-outline-secondary btn-sm"
+                  onClick={onReturnToMonth}
+                >
+                  Return to Month View
+                </button>
+              )}
+            </div>
+            <div className="card-body">
+              {/* Search and Sort Controls */}
+              <div className="row mb-3">
+                <div className="col-md-6">
+                  <input
+                    type="text"
+                    className="form-control"
+                    placeholder="Search by name or status..."
+                    value={searchTerm}
+                    onChange={(e) => setSearchTerm(e.target.value)}
+                  />
+                </div>
+                <div className="col-md-6">
+                  <small className="text-muted">
+                    {(() => {
+                      const range = getItemRange();
+                      if (isDayView) {
+                        return `Showing ${range.start}-${range.end} of ${range.total} appointments for this day`;
+                      } else if (paginationInfo) {
+                        return `Showing ${range.start}-${range.end} of ${range.total} appointments (Page ${paginationInfo.currentPage} of ${paginationInfo.totalPages})`;
+                      } else {
+                        return `Showing ${range.start}-${range.end} of ${range.total} appointments`;
+                      }
+                    })()}
+                  </small>
+                </div>
+              </div>
+
+              <div className="table-responsive">
+                {isLoading && <p>Loading...</p>}
+                {!isLoading && !isError && (
+                  <table className="table">
+                    <thead>
+                      <tr>
+                        <th 
+                          scope="col" 
+                          style={{ cursor: 'pointer' }}
+                          onClick={() => handleSort('title')}
+                        >
+                          Name {getSortIcon('title')}
+                        </th>
+                        {!selectedDate && (
+                          <th 
+                            scope="col" 
+                            style={{ cursor: 'pointer' }}
+                            onClick={() => handleSort('start')}
+                          >
+                            Date {getSortIcon('start')}
+                          </th>
+                        )}
+                        <th scope="col">Time</th>
+                        <th 
+                          scope="col" 
+                          style={{ cursor: 'pointer' }}
+                          onClick={() => handleSort('status')}
+                        >
+                          Status {getSortIcon('status')}
+                        </th>
+                        <th scope="col">Child ID</th>
+                        <th scope="col">User ID</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {displayReservations && displayReservations.map((reservation) => formatTableRow(reservation))}
+                    </tbody>
+                  </table>
+                )}
+                {!isLoading && isError && <p>Error loading appointments.</p>}
+                {!isLoading && !isError && filteredReservations.length === 0 && (
+                  <p>No appointments found.</p>
+                )}
+              </div>
+              
+              {/* Pagination controls (only for full admin view) */}
+              {!isDayView && paginationInfo && paginationInfo.totalPages > 1 && (
+                <nav aria-label="Appointments pagination" className="mt-3">
+                  <ul className="pagination justify-content-center">
+                    <li className={`page-item ${!paginationInfo.hasPreviousPage ? 'disabled' : ''}`}>
+                      <button 
+                        className="page-link" 
+                        onClick={() => setCurrentPage(paginationInfo.currentPage - 1)}
+                        disabled={!paginationInfo.hasPreviousPage}
+                      >
+                        Previous
+                      </button>
+                    </li>
+                    
+                    {/* Show page numbers */}
+                    {Array.from({ length: Math.min(5, paginationInfo.totalPages) }, (_, i) => {
+                      const pageNum = Math.max(1, Math.min(paginationInfo.totalPages - 4, paginationInfo.currentPage - 2)) + i;
+                      if (pageNum > paginationInfo.totalPages) return null;
+                      
+                      return (
+                        <li key={pageNum} className={`page-item ${paginationInfo.currentPage === pageNum ? 'active' : ''}`}>
+                          <button 
+                            className="page-link" 
+                            onClick={() => setCurrentPage(pageNum)}
+                          >
+                            {pageNum}
+                          </button>
+                        </li>
+                      );
+                    })}
+                    
+                    <li className={`page-item ${!paginationInfo.hasNextPage ? 'disabled' : ''}`}>
+                      <button 
+                        className="page-link" 
+                        onClick={() => setCurrentPage(paginationInfo.currentPage + 1)}
+                        disabled={!paginationInfo.hasNextPage}
+                      >
+                        Next
+                      </button>
+                    </li>
+                  </ul>
+                </nav>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default AdminReservations;

--- a/src/components/Dashboard/AdminReservations.js
+++ b/src/components/Dashboard/AdminReservations.js
@@ -176,9 +176,9 @@ const AdminReservations = ({ selectedDate = null, showReturnButton = false, onRe
                 </button>
               )}
             </div>
-            <div className="card-body">
+            <div className="card-body d-flex flex-column">
               {/* Search and Sort Controls */}
-              <div className="row mb-3">
+              <div className="row mb-3 flex-shrink-0">
                 <div className="col-md-6">
                   <input
                     type="text"
@@ -204,7 +204,7 @@ const AdminReservations = ({ selectedDate = null, showReturnButton = false, onRe
                 </div>
               </div>
 
-              <div className="table-responsive">
+              <div className="table-responsive flex-fill overflow-auto">
                 {isLoading && <p>Loading...</p>}
                 {!isLoading && !isError && (
                   <table className="table">
@@ -251,7 +251,7 @@ const AdminReservations = ({ selectedDate = null, showReturnButton = false, onRe
               
               {/* Pagination controls (only for full admin view) */}
               {!isDayView && paginationInfo && paginationInfo.totalPages > 1 && (
-                <nav aria-label="Appointments pagination" className="mt-3">
+                <nav aria-label="Appointments pagination" className="mt-3 flex-shrink-0">
                   <ul className="pagination justify-content-center">
                     <li className={`page-item ${!paginationInfo.hasPreviousPage ? 'disabled' : ''}`}>
                       <button 

--- a/src/components/Dashboard/AdminReservations.js
+++ b/src/components/Dashboard/AdminReservations.js
@@ -36,20 +36,6 @@ const AdminReservations = ({ selectedDate = null, showReturnButton = false, onRe
     }
   };
 
-  // Calculate the range of items being displayed
-  const getItemRange = () => {
-    if (isDayView) {
-      return { start: 1, end: filteredReservations.length, total: filteredReservations.length };
-    }
-    
-    if (paginationInfo) {
-      const start = (paginationInfo.currentPage - 1) * pageSize + 1;
-      const end = Math.min(paginationInfo.currentPage * pageSize, paginationInfo.totalCount);
-      return { start, end, total: paginationInfo.totalCount };
-    }
-    
-    return { start: 1, end: displayReservations.length, total: displayReservations.length };
-  };
   
   const [searchTerm, setSearchTerm] = useState("");
   const [sortField, setSortField] = useState("start");
@@ -112,8 +98,24 @@ const AdminReservations = ({ selectedDate = null, showReturnButton = false, onRe
     return filtered;
   }, [reservations, selectedDate, searchTerm, sortField, sortDirection]);
 
+
   // For now, use filteredReservations directly (pagination will be handled by the hook)
   const displayReservations = filteredReservations;
+
+  // Calculate the range of items being displayed
+  const getItemRange = () => {
+    if (isDayView) {
+      return { start: 1, end: filteredReservations.length, total: filteredReservations.length };
+    }
+    
+    if (paginationInfo) {
+      const start = (paginationInfo.currentPage - 1) * pageSize + 1;
+      const end = Math.min(paginationInfo.currentPage * pageSize, paginationInfo.totalCount);
+      return { start, end, total: paginationInfo.totalCount };
+    }
+    
+    return { start: 1, end: displayReservations.length, total: displayReservations.length };
+  };
 
   const handleSort = (field) => {
     if (sortField === field) {

--- a/src/components/Dashboard/DashHome.js
+++ b/src/components/Dashboard/DashHome.js
@@ -1,14 +1,53 @@
 import React, { useRef, useState, useEffect, useCallback } from 'react';
 import DashboardCalendar from '../Shared/DashboardCalendar';
 import AdminCalendarInteractionColumn from './AdminCalendarInteractionColumn';
-import { AdminPanelContextProvider } from './AdminPanelContext';
+import AdminReservations from './AdminReservations';
+import { AdminPanelContextProvider, useAdminPanelContext } from './AdminPanelContext';
+
+// Inner component that uses the AdminPanelContext
+function DashHomeContent({ calCardRef, calHeight }) {
+  const { selectedDate, setSelectedDate } = useAdminPanelContext();
+
+  const handleReturnToMonth = () => {
+    setSelectedDate(null);
+  };
+
+  return (
+    <div className="row align-items-start">
+      <div className="col-12 col-xl-8 mb-4 d-flex flex-column">
+        <div
+          ref={calCardRef}
+          id="calendar-card"
+          className="card flex-fill d-flex flex-column"
+        >
+          {selectedDate ? (
+            <AdminReservations 
+              selectedDate={selectedDate}
+              showReturnButton={true}
+              onReturnToMonth={handleReturnToMonth}
+            />
+          ) : (
+            <>
+              <h5 className="card-header">Monthly Overview</h5>
+              <div className="card-body flex-fill">
+                <DashboardCalendar />
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+
+      <AdminCalendarInteractionColumn calHeight={calHeight} />
+    </div>
+  );
+}
 
 export default function DashHome() {
   // For measuring the calendar's height
   const calCardRef = useRef(null);
   const [calHeight, setCalHeight] = useState(0);
 
-  // Measure the calendar card’s full height
+  // Measure the calendar card's full height
   const measure = useCallback(() => {
     const el = calCardRef.current;
     if (el) {
@@ -97,23 +136,7 @@ export default function DashHome() {
 
       {/* The notifications feed on the right has its height dynamically set to match the calendar on the left using the calCardRef */}
       <AdminPanelContextProvider>
-        <div className="row align-items-start">
-
-          <div className="col-12 col-xl-8 mb-4 d-flex flex-column">
-            <div
-              ref={calCardRef}
-              id="calendar-card"
-              className="card flex-fill d-flex flex-column"
-            >
-              <h5 className="card-header">Monthly Overview</h5>
-              <div className="card-body flex-fill">
-                <DashboardCalendar />
-              </div>
-            </div>
-          </div>
-
-          <AdminCalendarInteractionColumn calHeight={calHeight} />
-        </div>
+        <DashHomeContent calCardRef={calCardRef} calHeight={calHeight} />
       </AdminPanelContextProvider>
       
     </>

--- a/src/components/Dashboard/DashHome.js
+++ b/src/components/Dashboard/DashHome.js
@@ -19,6 +19,7 @@ function DashHomeContent({ calCardRef, calHeight }) {
           ref={calCardRef}
           id="calendar-card"
           className="card flex-fill d-flex flex-column"
+          style={calHeight > 0 ? { height: calHeight } : {}}
         >
           {selectedDate ? (
             <AdminReservations 
@@ -29,7 +30,7 @@ function DashHomeContent({ calCardRef, calHeight }) {
           ) : (
             <>
               <h5 className="card-header">Monthly Overview</h5>
-              <div className="card-body flex-fill">
+              <div className="card-body flex-fill overflow-auto">
                 <DashboardCalendar />
               </div>
             </>

--- a/src/components/Dashboard/DashNav.js
+++ b/src/components/Dashboard/DashNav.js
@@ -27,6 +27,11 @@ const DashNav = ({ setCurrentView }) => {
                 <span className="ml-2">View Contacts</span>
               </a>
             </li>
+            <li className="nav-item">
+              <a className="nav-link" href="#" onClick={() => setCurrentView('reservations')} >
+                <span className="ml-2">View Reservations</span>
+              </a>
+            </li>
 
           </ul>
         </div>

--- a/src/components/Dashboard/ManageReservationsPage.js
+++ b/src/components/Dashboard/ManageReservationsPage.js
@@ -94,11 +94,19 @@ const ManageReservationsPage = ({ enableAggregates = false }) => {
     mutationKey: ['changeReservationTime'],
     mutationFn: async ({ id, newStart, newEnd }) => dbService.changeReservationTime(id, newStart, newEnd),
     onSuccess: () => {
-      queryClient.invalidateQueries(
-        ['adminCalendarReservationsByMonth'],
-        selectedDate.getUTCMonth(),
-        selectedDate.getUTCFullYear()
-      )
+      // Invalidate all relevant query keys based on the current view
+      const month = selectedDate.getUTCMonth();
+      const year = selectedDate.getUTCFullYear();
+      const day = selectedDate.getUTCDate();
+      
+      // Invalidate day view query
+      queryClient.invalidateQueries(['calendarReservationsByDay', day, month, year]);
+      
+      // Invalidate month view query  
+      queryClient.invalidateQueries(['calendarReservationsByMonth', month, year]);
+      
+      // Invalidate week view query (in case user switches to week view)
+      queryClient.invalidateQueries(['calendarReservationsByWeek', day, month, year]);
     },
     onError: (err) => console.error("Error changing reservation time: ", err)
   })
@@ -167,11 +175,19 @@ const ManageReservationsPage = ({ enableAggregates = false }) => {
       mutationKey: ['changeReservationStatus'],
       mutationFn: async ({ id, status }) => dbService.changeReservationStatus(id, status),
       onSuccess: () => {
-        queryClient.invalidateQueries(
-          ['adminCalendarReservationsByMonth'],
-          selectedDate.getUTCMonth(),
-          selectedDate.getUTCFullYear()
-        );
+        // Invalidate all relevant query keys based on the current view
+        const month = selectedDate.getUTCMonth();
+        const year = selectedDate.getUTCFullYear();
+        const day = selectedDate.getUTCDate();
+        
+        // Invalidate day view query
+        queryClient.invalidateQueries(['calendarReservationsByDay', day, month, year]);
+        
+        // Invalidate month view query  
+        queryClient.invalidateQueries(['calendarReservationsByMonth', month, year]);
+        
+        // Invalidate week view query (in case user switches to week view)
+        queryClient.invalidateQueries(['calendarReservationsByWeek', day, month, year]);
       },
       onError: (error) => {
         console.error('Error updating reservation status:', error);

--- a/src/components/Dashboard/ManageReservationsPage.js
+++ b/src/components/Dashboard/ManageReservationsPage.js
@@ -39,12 +39,14 @@ const ManageReservationsPage = () => {
   }, [rawEvents]);
 
   useEffect(() => {
+    if (!selectedDate) return;
+    
     setMonthYear({
       month: selectedDate.getUTCMonth(),
       year: selectedDate.getUTCFullYear(),
     });
 
-    if (!selectedDate || !calendarComponentRef.current) return;
+    if (!calendarComponentRef.current) return;
     // Use a timeout to ensure the calendar is fully rendered before navigating
     const handle = setTimeout(() => {
       const api = calendarComponentRef.current.getApi();

--- a/src/components/Pages/AdminDashboard.js
+++ b/src/components/Pages/AdminDashboard.js
@@ -27,20 +27,7 @@ const AdminDashboard = () => {
 
   return (
     <>
-      <nav className="navbar navbar-light bg-light p-3">
-        <div className="d-flex col-12 col-md-2 col-lg-2 mb-2 mb-lg-0 flex-wrap flex-md-nowrap justify-content-between">
-          <a className="navbar-brand text-secondary" href="#" >
-            Admin Dashboard
-          </a>
-          <button className="navbar-toggler d-md-none collapsed mb-3" type="button" data-toggle="collapse" data-target="#sidebar" aria-controls="sidebar" aria-expanded="false" aria-label="Toggle navigation">
-            <span className="navbar-toggler-icon"></span>
-          </button>
-        </div>
-        <div className="col-12 col-md-4 col-lg-2">
-          <input className="form-control form-control-dark" type="text" placeholder="Search" aria-label="Search" />
-        </div>
-      </nav>
-      <div className="container-fluid">
+      <div className="container-fluid" style={{ borderTop: '1px solid rgb(33, 105, 187)' }}>
         <div className="row">
           <DashNav setCurrentView={setCurrentView} />
           <main className="col-md-10 ml-sm-auto col-lg-10 px-md-4 py-4">

--- a/src/components/Pages/AdminDashboard.js
+++ b/src/components/Pages/AdminDashboard.js
@@ -4,15 +4,10 @@ import DashNav from '../Dashboard/DashNav';
 import AdminUsers from '../Dashboard/AdminUsers';
 import AdminContacts from '../Dashboard/AdminContacts';
 import AdminChildren from '../Dashboard/AdminChildren';
+import AdminReservations from '../Dashboard/AdminReservations';
 
 const AdminDashboard = () => {
   const [currentView, setCurrentView] = useState('dashboard');
-
-  const dashboardWidgetStyle = {
-    background: 'aliceblue',
-    border: '2px solid black',
-    padding: '25px',
-  }
 
   const renderView = () => {
     switch (currentView) {
@@ -22,6 +17,8 @@ const AdminDashboard = () => {
         return <AdminChildren />;
       case 'contacts':
         return <AdminContacts />;
+      case 'reservations':
+        return <AdminReservations />;
       case 'dashboard':
       default:
         return <DashHome />;
@@ -54,55 +51,6 @@ const AdminDashboard = () => {
     </>
   );
 };
-{/* // <Grid container>
-    //   <Grid item xs={12}>
-    //     <h1>Admin Dashboard</h1>
-    //     <p>Here is where the admin dashboard content will go.</p>
-    //   </Grid>
-
-    //   <Grid item xs={3} sx={dashboardWidgetStyle}>
-    //     <h2 style={{marginBlockStart: '0'}}>Admin Actions</h2>
-    //     <ul>
-    //       <li>View User Registrations</li>
-    //       <li>View Child Registrations</li>
-    //       <li>View Contact Registrations</li>
-    //     </ul>
-    //   </Grid>
-    //   <Grid item xs={3} sx={dashboardWidgetStyle}>
-    //   <h2 style={{marginBlockStart: '0'}}>Reports</h2>
-    //     <ul>
-    //       <li>View User Report</li>
-    //       <li>View Child Report</li>
-    //       <li>View Contact Report</li>
-    //     </ul>
-    //   </Grid>
-    //   <Grid item xs={3} sx={dashboardWidgetStyle}>
-    //   <h2 style={{marginBlockStart: '0'}}>Settings</h2>
-    //     <ul>
-    //       <li>Manage Users</li>
-    //       <li>Manage Children</li>
-    //       <li>Manage Contacts</li>
-    //     </ul>
-    //   </Grid>
-    //   <Grid item xs={3} sx={dashboardWidgetStyle}>
-    //   <h2 style={{marginBlockStart: '0'}}>System</h2>
-    //     <ul>
-    //       <li>View Logs</li>
-    //       <li>View Errors</li>
-    //       <li>View System Status</li>
-    //     </ul>
-    //   </Grid>
-
-    //   <Grid item xs={3} sx={dashboardWidgetStyle}>
-    //     <h2 style={{marginBlockStart: '0'}}>Calendar</h2>
-    //     <p>View and manage events on the calendar.</p>
-    //   </Grid> 
-    //   <Grid item xs={9}>
-    //     <Calendar />
-    //   </Grid>
-
-
-    // </Grid> */}
 
 
 export default AdminDashboard;

--- a/src/components/Shared/AggregateTimeSlot.js
+++ b/src/components/Shared/AggregateTimeSlot.js
@@ -1,0 +1,36 @@
+import React, { useEffect } from 'react';
+
+/**
+ * Component for displaying aggregate time slot events on the calendar
+ * Shows count of confirmed appointments in a 15-minute time slot
+ */
+const AggregateTimeSlot = ({ event, backgroundColor }) => {
+  useEffect(() => {
+    const currentNode = document.querySelector(`[data-event-id="${event.id}"]`);
+    if (currentNode) {
+      let ancestor = currentNode.closest('a'); // This finds the nearest anchor tag which is usually the event wrapper
+      if (ancestor) {
+        ancestor.style.backgroundColor = backgroundColor; // Change to desired background color
+        ancestor.style.borderColor = backgroundColor; // Change to desired border color
+      }
+    }
+  }, [event, backgroundColor]);
+
+  return (
+    <div 
+      className='fc-event-main' 
+      data-event-id={event.id} 
+      style={{ 
+        backgroundColor, 
+        padding: '5px', 
+        borderRadius: '5px', 
+        color: 'white',
+        fontWeight: 'bold'
+      }}
+    >
+      <b>{event.title}</b>
+    </div>
+  );
+};
+
+export default AggregateTimeSlot;

--- a/src/components/Shared/StyledCalendarEvent.js
+++ b/src/components/Shared/StyledCalendarEvent.js
@@ -15,13 +15,13 @@ const StyledCalendarEvent = ({event, backgroundColor}) => {
   return (
     <div className='fc-event-main' data-event-id={event.id} style={{ backgroundColor, padding: '5px', borderRadius: '5px', color: 'white' }}>
         <b>{event.title}</b>
-        {event.extendedProps.status === 'pending' && (
+        {event.status === 'pending' && (
             <i style={{ marginLeft: '5px' }}>Pending</i>
         )}
-        {event.extendedProps.status === 'confirmed' && (
+        {event.status === 'confirmed' && (
             <i style={{ marginLeft: '5px' }}>Approved</i>
         )}
-        {event.extendedProps.status === 'unpaid' && (
+        {event.status === 'unpaid' && (
             <i style={{ marginLeft: '5px' }}>Unpaid</i>
         )}
     </div>


### PR DESCRIPTION
This pull request implements functionality to display a list of bookings by day on the admin dashboard. The implementation adds a new AdminReservations component that can show either all reservations (paginated) or filtered reservations for a specific selected date.

Key changes include:

- Added a new AdminReservations component with sorting, filtering, and pagination capabilities
- Integrated day-specific reservation viewing into the main dashboard calendar
- Added navigation menu item for viewing all reservations
- Update daily view calendar to display overall count of confirmed appointments and fully show pending appointments
- Daily calendar now rolls up all confirmed appointments into 15m aggregate blocks for readabilty.